### PR TITLE
Add tagged name

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -10,6 +10,7 @@ module Github.Data (
   module Github.Data.Gists,
   module Github.Data.GitData,
   module Github.Data.Issues,
+  module Github.Data.Name,
   module Github.Data.PullRequests,
   module Github.Data.Teams,
   ) where
@@ -36,6 +37,7 @@ import Github.Data.Definitions
 import Github.Data.Gists
 import Github.Data.GitData
 import Github.Data.Issues
+import Github.Data.Name
 import Github.Data.PullRequests
 import Github.Data.Teams
 

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -9,6 +9,8 @@ import GHC.Generics (Generic)
 import qualified Control.Exception as E
 import qualified Data.Map as M
 
+import Github.Data.Name
+
 -- | The options for querying commits.
 data CommitQueryOption = CommitQuerySha String
                        | CommitQueryPath String
@@ -34,14 +36,14 @@ instance NFData GithubDate
 
 data GithubOwner = GithubUser {
    githubOwnerAvatarUrl :: String
-  ,githubOwnerLogin :: String
+  ,githubOwnerLogin :: Name GithubOwner
   ,githubOwnerUrl :: String
   ,githubOwnerId :: Int
   ,githubOwnerGravatarId :: Maybe String
   }
   | GithubOrganization {
    githubOwnerAvatarUrl :: String
-  ,githubOwnerLogin :: String
+  ,githubOwnerLogin :: Name GithubOwner
   ,githubOwnerUrl :: String
   ,githubOwnerId :: Int
 } deriving (Show, Data, Typeable, Eq, Ord, Generic)
@@ -97,7 +99,7 @@ data Organization = Organization {
    organizationType :: String
   ,organizationBlog :: Maybe String
   ,organizationLocation :: Maybe String
-  ,organizationLogin :: String
+  ,organizationLogin :: Name Organization
   ,organizationFollowers :: Int
   ,organizationCompany :: Maybe String
   ,organizationAvatarUrl :: String
@@ -137,7 +139,7 @@ data Repo = Repo {
   ,repoUpdatedAt :: Maybe GithubDate
   ,repoWatchers :: Maybe Int
   ,repoOwner :: GithubOwner
-  ,repoName :: String
+  ,repoName :: Name Repo
   ,repoLanguage :: Maybe String
   ,repoMasterBranch :: Maybe String
   ,repoPushedAt :: Maybe GithubDate   -- ^ this is Nothing for new repositories
@@ -155,7 +157,7 @@ data Repo = Repo {
 
 instance NFData Repo
 
-data RepoRef = RepoRef GithubOwner String -- Repo owner and name
+data RepoRef = RepoRef GithubOwner (Name Repo) -- Repo owner and name
  deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
 instance NFData RepoRef
@@ -223,7 +225,7 @@ instance NFData ContentInfo
 data Contributor
   -- | An existing Github user, with their number of contributions, avatar
   -- URL, login, URL, ID, and Gravatar ID.
-  = KnownContributor Int String String String Int String
+  = KnownContributor Int String (Name Contributor) String Int String
   -- | An unknown Github user with their number of contributions and recorded name.
   | AnonymousContributor Int String
  deriving (Show, Data, Typeable, Eq, Ord, Generic)
@@ -262,7 +264,7 @@ data DetailedOwner = DetailedUser {
   ,detailedOwnerUrl :: String
   ,detailedOwnerId :: Int
   ,detailedOwnerHtmlUrl :: String
-  ,detailedOwnerLogin :: String
+  ,detailedOwnerLogin :: Name GithubOwner
   }
   | DetailedOrganization {
    detailedOwnerCreatedAt :: GithubDate
@@ -280,7 +282,7 @@ data DetailedOwner = DetailedUser {
   ,detailedOwnerUrl :: String
   ,detailedOwnerId :: Int
   ,detailedOwnerHtmlUrl :: String
-  ,detailedOwnerLogin :: String
+  ,detailedOwnerLogin :: Name GithubOwner
 } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
 instance NFData DetailedOwner

--- a/Github/Data/Name.hs
+++ b/Github/Data/Name.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+module Github.Data.Name where
+
+import Control.DeepSeq   (NFData(..))
+import Data.Aeson.Compat (FromJSON(..), ToJSON(..))
+import Data.Data         (Data, Typeable)
+import Data.Hashable     (Hashable)
+import Data.String       (IsString(..))
+import GHC.Generics      (Generic)
+
+newtype Name entity = N String
+    deriving (Eq, Ord, Show, Read, Generic, Typeable, Data)
+
+untagName :: Name entity -> String
+untagName (N name) = name
+
+instance Hashable (Name entity)
+
+instance NFData (Name entity) where
+    rnf (N s) = rnf s
+
+instance FromJSON (Name entity) where
+    parseJSON = fmap N . parseJSON
+
+instance ToJSON (Name entity) where
+    toJSON = toJSON . untagName
+
+instance IsString (Name entity) where
+    fromString = N

--- a/Github/Organizations.hs
+++ b/Github/Organizations.hs
@@ -13,23 +13,23 @@ import Github.Private
 -- | The public organizations for a user, given the user's login, with authorization
 --
 -- > publicOrganizationsFor' (Just ("github-username", "github-password")) "mike-burns"
-publicOrganizationsFor' :: Maybe GithubAuth -> String -> IO (Either Error [SimpleOrganization])
-publicOrganizationsFor' auth userName = githubGet' auth ["users", userName, "orgs"]
+publicOrganizationsFor' :: Maybe GithubAuth -> Name GithubOwner -> IO (Either Error [SimpleOrganization])
+publicOrganizationsFor' auth userName = githubGet' auth ["users", untagName userName, "orgs"]
 
 -- | The public organizations for a user, given the user's login.
 --
 -- > publicOrganizationsFor "mike-burns"
-publicOrganizationsFor :: String -> IO (Either Error [SimpleOrganization])
+publicOrganizationsFor :: Name GithubOwner -> IO (Either Error [SimpleOrganization])
 publicOrganizationsFor = publicOrganizationsFor' Nothing
 
 -- | Details on a public organization. Takes the organization's login.
 --
 -- > publicOrganization' (Just ("github-username", "github-password")) "thoughtbot"
-publicOrganization' :: Maybe GithubAuth -> String -> IO (Either Error Organization)
-publicOrganization' auth reqOrganizationName = githubGet' auth ["orgs", reqOrganizationName]
+publicOrganization' :: Maybe GithubAuth -> Name Organization -> IO (Either Error Organization)
+publicOrganization' auth reqOrganizationName = githubGet' auth ["orgs", untagName reqOrganizationName]
 
 -- | Details on a public organization. Takes the organization's login.
 --
 -- > publicOrganization "thoughtbot"
-publicOrganization :: String -> IO (Either Error Organization)
+publicOrganization :: Name Organization -> IO (Either Error Organization)
 publicOrganization = publicOrganization' Nothing

--- a/fixtures/user-organizations.json
+++ b/fixtures/user-organizations.json
@@ -1,0 +1,9 @@
+[
+  {
+    "login": "github",
+    "id": 1,
+    "url": "https://api.github.com/orgs/github",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "description": "A great organization"
+  }
+]

--- a/github.cabal
+++ b/github.cabal
@@ -142,6 +142,7 @@ Library
                    Github.Data.Issues,
                    Github.Data.PullRequests,
                    Github.Data.Teams,
+                   Github.Data.Name,
                    Github.Events,
                    Github.Gists,
                    Github.Gists.Comments,
@@ -212,8 +213,10 @@ test-suite github-test
   hs-source-dirs: spec
   other-modules:
     Github.UsersSpec
+    Github.OrganizationsSpec
   main-is: Spec.hs
   build-depends: base >= 4.0 && < 5.0,
+                 base-compat,
                  aeson-extra >= 0.2.0.0 && <0.3,
                  github,
                  file-embed,

--- a/spec/Github/OrganizationsSpec.hs
+++ b/spec/Github/OrganizationsSpec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Github.OrganizationsSpec where
+
+import Github.Auth             (GithubAuth (..))
+import Github.Data.Definitions (SimpleOrganization (..))
+import Github.Organizations    (publicOrganizationsFor')
+
+import Data.Aeson.Compat  (eitherDecodeStrict)
+import Data.Either.Compat (isRight)
+import Data.FileEmbed     (embedFile)
+import System.Environment (lookupEnv)
+import Test.Hspec         (Spec, describe, it, pendingWith, shouldBe,
+                           shouldSatisfy)
+
+fromRightS :: Show a => Either a b -> b
+fromRightS (Right b) = b
+fromRightS (Left a) = error $ "Expected a Right and got a Left" ++ show a
+
+withAuth :: (GithubAuth -> IO ()) -> IO ()
+withAuth action = do
+  mtoken <- lookupEnv "GITHUB_TOKEN"
+  case mtoken of
+    Nothing    -> pendingWith "no GITHUB_TOKEN"
+    Just token -> action (GithubOAuth token)
+
+spec :: Spec
+spec =
+  describe "publicOrganizationsFor'" $ do
+    it "decodes simple organization json" $ do
+      let orgs = eitherDecodeStrict $(embedFile "fixtures/user-organizations.json")
+      simpleOrganizationLogin (head $ fromRightS orgs) `shouldBe` "github"
+
+    it "returns information about the user's organizations" $ withAuth $ \auth -> do
+      orgs <- publicOrganizationsFor' (Just auth) "mike-burns"
+      orgs  `shouldSatisfy` isRight

--- a/spec/Github/UsersSpec.hs
+++ b/spec/Github/UsersSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Github.UsersSpec where
 
 import Github.Auth (GithubAuth(..))


### PR DESCRIPTION
This is an approach to resolve https://github.com/jwiegley/github/issues/84

Other ideas:
- Similarly we can introduce `newtype Identifier entity = Ident Int` for identifiers.
- As commit hash are all over the github, they could have own `newtype` or be `Name Commit` too.
- `URL` could be a newtype or type, they aren't passed around, so `type` might be enough?
- Also we can introduce `type Count = Int` . E.g. issue has `issueNumber` which isn't count, but also has `issueComments` which is.
- whether it's `Name Organisation` or `Name SimpleOrganisation` is arbitrary. I'd prefer using the *big* data. But then `DetailedGithubOwner` and `GithubOwner` are other way around.

ping @bitemyapp 

Please comment.

P.S. I can do this refactor as I continue with https://github.com/jwiegley/github/pull/131