### PR TITLE
Add search issues functionality

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -550,6 +550,12 @@ instance FromJSON SearchReposResult where
                       <*> o .:< "items"
   parseJSON _ = fail "Could not build a SearchReposResult"
 
+instance FromJSON SearchIssuesResult where
+  parseJSON (Object o) =
+    SearchIssuesResult <$> o .: "total_count"
+                       <*> o .:< "items"
+  parseJSON _ = fail "Could not build a SearchIssuesResult"
+
 instance FromJSON Repo where
   parseJSON (Object o) =
     Repo <$> o .:? "ssh_url"

--- a/Github/Data/Issues.hs
+++ b/Github/Data/Issues.hs
@@ -87,6 +87,13 @@ data IssueComment = IssueComment {
 
 instance NFData IssueComment
 
+data SearchIssuesResult = SearchIssuesResult {
+   searchIssuesTotalCount :: Int
+  ,searchIssuesIssues :: [Issue]
+} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData SearchIssuesResult
+
 data EventType =
     Mentioned     -- ^ The actor was @mentioned in an issue body.
   | Subscribed    -- ^ The actor subscribed to receive notifications for an issue.

--- a/Github/Search.hs
+++ b/Github/Search.hs
@@ -5,6 +5,8 @@ module Github.Search(
 ,searchRepos
 ,searchCode'
 ,searchCode
+,searchIssues'
+,searchIssues
 ,module Github.Data
 ) where
 
@@ -38,5 +40,19 @@ searchCode' auth queryString = githubGetWithQueryString' auth ["search", "code"]
 -- > searchCode "q=addClass+in:file+language:js+repo:jquery/jquery"
 searchCode :: String -> IO (Either Error SearchCodeResult)
 searchCode = searchCode' Nothing 
+
+-- | Perform an issue search.
+-- | With authentication.
+--
+-- > searchIssues' (Just $ GithubBasicAuth "github-username" "github-password') "q=a repo%3Aphadej%2Fgithub&per_page=100"
+searchIssues' :: Maybe GithubAuth -> String -> IO (Either Error SearchIssuesResult)
+searchIssues' auth queryString = githubGetWithQueryString' auth ["search", "issues"] queryString
+
+-- | Perform an issue search.
+-- | Without authentication.
+--
+-- > searchIssues "q=a repo%3Aphadej%2Fgithub&per_page=100"
+searchIssues :: String -> IO (Either Error SearchIssuesResult)
+searchIssues = searchIssues' Nothing
 
 

--- a/fixtures/issueSearch.json
+++ b/fixtures/issueSearch.json
@@ -1,0 +1,96 @@
+{
+  "total_count": 2,
+  "incomplete_results": false,
+  "items": [
+    {
+      "url": "https://api.github.com/repos/phadej/github/issues/130",
+      "labels_url": "https://api.github.com/repos/phadej/github/issues/130/labels{/name}",
+      "comments_url": "https://api.github.com/repos/phadej/github/issues/130/comments",
+      "events_url": "https://api.github.com/repos/phadej/github/issues/130/events",
+      "html_url": "https://github.com/phadej/github/pull/130",
+      "id": 123898390,
+      "number": 130,
+      "title": "Make test runner more robust",
+      "user": {
+        "login": "phadej",
+        "id": 51087,
+        "avatar_url": "https://avatars.githubusercontent.com/u/51087?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/phadej",
+        "html_url": "https://github.com/phadej",
+        "followers_url": "https://api.github.com/users/phadej/followers",
+        "following_url": "https://api.github.com/users/phadej/following{/other_user}",
+        "gists_url": "https://api.github.com/users/phadej/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/phadej/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/phadej/subscriptions",
+        "organizations_url": "https://api.github.com/users/phadej/orgs",
+        "repos_url": "https://api.github.com/users/phadej/repos",
+        "events_url": "https://api.github.com/users/phadej/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/phadej/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+
+      ],
+      "state": "closed",
+      "locked": false,
+      "assignee": null,
+      "milestone": null,
+      "comments": 0,
+      "created_at": "2015-12-25T21:37:39Z",
+      "updated_at": "2015-12-26T08:57:52Z",
+      "closed_at": "2015-12-25T23:32:12Z",
+      "pull_request": {
+        "url": "https://api.github.com/repos/phadej/github/pulls/130",
+        "html_url": "https://github.com/phadej/github/pull/130",
+        "diff_url": "https://github.com/phadej/github/pull/130.diff",
+        "patch_url": "https://github.com/phadej/github/pull/130.patch"
+      },
+      "body": "As they use access token, it's highly unlikely it will be rate limited. ATM there's only one request per test job. i.e. travis could be re-enabled.\r\n\r\nExample run https://travis-ci.org/phadej/github/builds/98815089\r\nSome tests are pending as secret is made for this `jwiegley/github` repository.",
+      "score": 0.75566536
+    },
+    {
+      "url": "https://api.github.com/repos/phadej/github/issues/127",
+      "labels_url": "https://api.github.com/repos/phadej/github/issues/127/labels{/name}",
+      "comments_url": "https://api.github.com/repos/phadej/github/issues/127/comments",
+      "events_url": "https://api.github.com/repos/phadej/github/issues/127/events",
+      "html_url": "https://github.com/phadej/github/issues/127",
+      "id": 119694665,
+      "number": 127,
+      "title": "Decouple request creation from execution",
+      "user": {
+        "login": "phadej",
+        "id": 51087,
+        "avatar_url": "https://avatars.githubusercontent.com/u/51087?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/phadej",
+        "html_url": "https://github.com/phadej",
+        "followers_url": "https://api.github.com/users/phadej/followers",
+        "following_url": "https://api.github.com/users/phadej/following{/other_user}",
+        "gists_url": "https://api.github.com/users/phadej/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/phadej/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/phadej/subscriptions",
+        "organizations_url": "https://api.github.com/users/phadej/orgs",
+        "repos_url": "https://api.github.com/users/phadej/repos",
+        "events_url": "https://api.github.com/users/phadej/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/phadej/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+
+      ],
+      "state": "open",
+      "locked": false,
+      "assignee": null,
+      "milestone": null,
+      "comments": 2,
+      "created_at": "2015-12-01T11:09:03Z",
+      "updated_at": "2015-12-25T19:15:33Z",
+      "closed_at": null,
+      "body": "After working with this API, and making few others, I found that separating request creation and execution is better (i.e. more flexible) design.\r\n\r\nNow one cannot use different network client or add new endpoints.\r\n\r\nShorly\r\n\r\n```hs\r\n-- New stuff:\r\ndata GithubRequest a = GithubRequestGet Url\r\n                     | ...\r\n\r\n-- or alternatively\r\ndata GithubRequest a where\r\n  GithubRequestGet :: Url -> GithubRequest a\r\n  GithubRequestMultiGet :: Url -> GithubRequest [a]\r\n\r\nexecGithubRequest :: FromJSON a => GithubRequest a -> IO (Either Error a)\r\nexecGithubRequest' :: FromJSON a => Maybe GithubAuth -> GithubRequest a -> IO (Either Error a)\r\n\r\npublicOrganizationForRequest :: String -> GithubRequest [SimpleOrganisation]\r\npublicOrganizationForRequest org = GithubRequestGet ...\r\n\r\n-- Old IO methods become:\r\npublicOrganizationsFor :: String -> IO (Either Error [SimpleOrganization])\r\npublicOrganizationsFor = execGithubRequest . publicOrganizationForRequest\r\n\r\npublicOrganizationsFor' :: Maybe GithubAuth -> String -> IO (Either Error [SimpleOrganization])\r\npublicOrganizationsFor' auth = execGithubRequest' auth . publicOrganizationForRequest\r\n```\r\n\r\nHow does this sound? I can make a refactoring, it's quite straight-forward.",
+      "score": 0.7265285
+    }
+  ]
+}

--- a/github.cabal
+++ b/github.cabal
@@ -84,6 +84,7 @@ Extra-source-files:  README.md
                     ,samples/Pulls/ShowCommits.hs
                     ,samples/Pulls/ShowPull.hs
                     ,samples/Search/SearchRepos.hs
+                    ,samples/Search/SearchIssues.hs
                     ,samples/Repos/Collaborators/IsCollaborator.hs
                     ,samples/Repos/Collaborators/ListCollaborators.hs
                     ,samples/Repos/Commits/CommitComment.hs

--- a/github.cabal
+++ b/github.cabal
@@ -215,6 +215,7 @@ test-suite github-test
   type: exitcode-stdio-1.0
   hs-source-dirs: spec
   other-modules:
+    Github.SearchSpec
     Github.UsersSpec
     Github.OrganizationsSpec
   main-is: Spec.hs

--- a/samples/Search/SearchIssues.hs
+++ b/samples/Search/SearchIssues.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+module SearchIssues where
+
+import qualified Github.Search as Github
+import Control.Monad (forM_)
+
+main = do
+  let query = "q=build%2Arepo%3Aphadej%2Fgithub&per_page=100"
+  let auth = Nothing
+  result <- Github.searchIssues' auth query
+  case result of
+    Left e  -> putStrLn $ "Error: " ++ show e
+    Right r -> do forM_ (Github.searchIssuesIssues r) (\i -> do
+                    putStrLn $ formatIssue i
+                    putStrLn ""
+                    )
+                  putStrLn $ "Count: " ++ show n ++ " build issues"
+      where n = Github.searchIssuesTotalCount r
+
+formatIssue issue =
+  (Github.githubOwnerLogin $ Github.issueUser issue) ++
+    " opened this issue " ++
+    (show $ Github.fromGithubDate $ Github.issueCreatedAt issue) ++ "\n" ++
+    (Github.issueState issue) ++ " with " ++
+    (show $ Github.issueComments issue) ++ " comments" ++ "\n\n" ++
+    (Github.issueTitle issue)

--- a/samples/Search/SearchIssues.hs
+++ b/samples/Search/SearchIssues.hs
@@ -5,7 +5,7 @@ import qualified Github.Search as Github
 import Control.Monad (forM_)
 
 main = do
-  let query = "q=build%2Arepo%3Aphadej%2Fgithub&per_page=100"
+  let query = "q=build%20repo%3Aphadej%2Fgithub&per_page=100"
   let auth = Nothing
   result <- Github.searchIssues' auth query
   case result of

--- a/spec/Github/SearchSpec.hs
+++ b/spec/Github/SearchSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Github.SearchSpec where
+
+import Control.Applicative ((<$>))
+import Data.Aeson.Compat   (eitherDecodeStrict)
+import Data.FileEmbed      (embedFile)
+import Test.Hspec          (Spec, describe, it, shouldBe)
+
+import Github.Data.Issues      (Issue(..), SearchIssuesResult(..))
+import Github.Search           (searchIssues)
+
+fromRightS :: Show a => Either a b -> b
+fromRightS (Right b) = b
+fromRightS (Left a) = error $ "Expected a Right and got a Left" ++ show a
+
+spec :: Spec
+spec = do
+  describe "searchIssues" $ do
+    it "decodes issue search response JSON" $ do
+      let searchIssuesResult = fromRightS $ eitherDecodeStrict $(embedFile "fixtures/issueSearch.json") :: SearchIssuesResult
+      searchIssuesTotalCount searchIssuesResult `shouldBe` 2
+
+      let issues = searchIssuesIssues searchIssuesResult
+      length issues `shouldBe` 2
+
+      let issue1 = head issues
+      issueId issue1 `shouldBe` 123898390
+      issueNumber issue1 `shouldBe` 130
+      issueTitle issue1 `shouldBe` "Make test runner more robust"
+      issueState issue1 `shouldBe` "closed"
+
+      let issue2 = issues !! 1
+      issueId issue2 `shouldBe` 119694665
+      issueNumber issue2 `shouldBe` 127
+      issueTitle issue2 `shouldBe` "Decouple request creation from execution"
+      issueState issue2 `shouldBe` "open"
+
+    it "performs an issue search via the API" $ do
+      let query = "q=Decouple in:title repo:phadej/github created:<=2015-12-01"
+      issues <- searchIssuesIssues . fromRightS <$> searchIssues query
+      length issues `shouldBe` 1
+      issueId (head issues) `shouldBe` 119694665

--- a/spec/Github/UsersSpec.hs
+++ b/spec/Github/UsersSpec.hs
@@ -2,18 +2,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Github.UsersSpec where
 
-import Control.Applicative ((<$>))
-import Data.Aeson.Compat   (eitherDecodeStrict)
-import Data.Either.Compat  (isRight)
-import Data.FileEmbed      (embedFile)
-import System.Environment  (lookupEnv)
-import Test.Hspec          (Spec, describe, it, pendingWith, shouldBe,
-                            shouldSatisfy)
+import Data.Aeson.Compat  (eitherDecodeStrict)
+import Data.Either.Compat (isRight)
+import Data.FileEmbed     (embedFile)
+import System.Environment (lookupEnv)
+import Test.Hspec         (Spec, describe, it, pendingWith, shouldBe,
+                           shouldSatisfy)
 
 import Github.Auth             (GithubAuth (..))
 import Github.Data.Definitions (DetailedOwner (..))
-import Github.Data.Issues      (Issue(..), SearchIssuesResult(..))
-import Github.Search           (searchIssues)
 import Github.Users            (userInfoCurrent', userInfoFor')
 
 fromRightS :: Show a => Either a b -> b
@@ -42,29 +39,3 @@ spec = do
     it "returns information about the autenticated user" $ withAuth $ \auth -> do
       userInfo <- userInfoCurrent' (Just auth)
       userInfo `shouldSatisfy` isRight
-
-  describe "searchIssues" $ do
-    it "decodes issue search response JSON" $ do
-      let searchIssuesResult = fromRightS $ eitherDecodeStrict $(embedFile "fixtures/issueSearch.json") :: SearchIssuesResult
-      searchIssuesTotalCount searchIssuesResult `shouldBe` 2
-
-      let issues = searchIssuesIssues searchIssuesResult
-      length issues `shouldBe` 2
-
-      let issue1 = head issues
-      issueId issue1 `shouldBe` 123898390
-      issueNumber issue1 `shouldBe` 130
-      issueTitle issue1 `shouldBe` "Make test runner more robust"
-      issueState issue1 `shouldBe` "closed"
-
-      let issue2 = issues !! 1
-      issueId issue2 `shouldBe` 119694665
-      issueNumber issue2 `shouldBe` 127
-      issueTitle issue2 `shouldBe` "Decouple request creation from execution"
-      issueState issue2 `shouldBe` "open"
-
-    it "performs an issue search via the API" $ do
-      let query = "q=Decouple in:title repo:phadej/github created:<=2015-12-01"
-      issues <- searchIssuesIssues . fromRightS <$> searchIssues query
-      length issues `shouldBe` 1
-      issueId (head issues) `shouldBe` 119694665

--- a/spec/Github/UsersSpec.hs
+++ b/spec/Github/UsersSpec.hs
@@ -2,15 +2,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Github.UsersSpec where
 
-import Data.Aeson.Compat  (eitherDecodeStrict)
-import Data.Either.Compat (isRight)
-import Data.FileEmbed     (embedFile)
-import System.Environment (lookupEnv)
-import Test.Hspec         (Spec, describe, it, pendingWith, shouldBe,
-                           shouldSatisfy)
+import Control.Applicative ((<$>))
+import Data.Aeson.Compat   (eitherDecodeStrict)
+import Data.Either.Compat  (isRight)
+import Data.FileEmbed      (embedFile)
+import System.Environment  (lookupEnv)
+import Test.Hspec          (Spec, describe, it, pendingWith, shouldBe,
+                            shouldSatisfy)
 
 import Github.Auth             (GithubAuth (..))
 import Github.Data.Definitions (DetailedOwner (..))
+import Github.Data.Issues      (Issue(..), SearchIssuesResult(..))
+import Github.Search           (searchIssues)
 import Github.Users            (userInfoCurrent', userInfoFor')
 
 fromRightS :: Show a => Either a b -> b
@@ -39,3 +42,29 @@ spec = do
     it "returns information about the autenticated user" $ withAuth $ \auth -> do
       userInfo <- userInfoCurrent' (Just auth)
       userInfo `shouldSatisfy` isRight
+
+  describe "searchIssues" $ do
+    it "decodes issue search response JSON" $ do
+      let searchIssuesResult = fromRightS $ eitherDecodeStrict $(embedFile "fixtures/issueSearch.json") :: SearchIssuesResult
+      searchIssuesTotalCount searchIssuesResult `shouldBe` 2
+
+      let issues = searchIssuesIssues searchIssuesResult
+      length issues `shouldBe` 2
+
+      let issue1 = head issues
+      issueId issue1 `shouldBe` 123898390
+      issueNumber issue1 `shouldBe` 130
+      issueTitle issue1 `shouldBe` "Make test runner more robust"
+      issueState issue1 `shouldBe` "closed"
+
+      let issue2 = issues !! 1
+      issueId issue2 `shouldBe` 119694665
+      issueNumber issue2 `shouldBe` 127
+      issueTitle issue2 `shouldBe` "Decouple request creation from execution"
+      issueState issue2 `shouldBe` "open"
+
+    it "performs an issue search via the API" $ do
+      let query = "q=Decouple in:title repo:phadej/github created:<=2015-12-01"
+      issues <- searchIssuesIssues . fromRightS <$> searchIssues query
+      length issues `shouldBe` 1
+      issueId (head issues) `shouldBe` 119694665


### PR DESCRIPTION
Adds issue search functionality as specified in https://developer.github.com/v3/search/#search-issues.

This PR adds two new public functions (`searchIssues` and `searchIssues'`) as well as a new data structure for the corresponding API response format (`SearchIssuesResult`) including a `FromJSON` instance. A new sample file is also provided.

The implementation is based on the existing search functions for repos and code.