### PR TITLE
Add HeaderQuery and RepoStarred Data

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -66,6 +66,7 @@ Library
     GitHub.Data.Request
     GitHub.Data.Search
     GitHub.Data.Teams
+    GitHub.Data.Activities
     GitHub.Data.Webhooks
     GitHub.Data.Webhooks.Validate
     GitHub.Endpoints.Activity.Starring

--- a/spec/GitHub/ActivitySpec.hs
+++ b/spec/GitHub/ActivitySpec.hs
@@ -4,6 +4,7 @@ module GitHub.ActivitySpec where
 
 import GitHub.Auth                        (Auth (..))
 import GitHub.Endpoints.Activity.Watching (watchersForR)
+import GitHub.Endpoints.Activity.Starring (myStarredAcceptStarR)
 import GitHub.Request                     (executeRequest)
 
 import Data.Either.Compat (isRight)
@@ -12,6 +13,8 @@ import System.Environment (lookupEnv)
 import Test.Hspec         (Spec, describe, it, pendingWith, shouldSatisfy)
 
 import qualified Data.Vector as V
+
+import GitHub.Data.Activities
 
 fromRightS :: Show a => Either a b -> b
 fromRightS (Right b) = b
@@ -31,3 +34,8 @@ spec = do
       cs <- executeRequest auth $ watchersForR "phadej" "github" Nothing
       cs `shouldSatisfy` isRight
       V.length (fromRightS cs) `shouldSatisfy` (> 10)
+  describe "myStarredR" $ do
+      it "works" $ withAuth $ \auth -> do
+          cs <- executeRequest auth $ myStarredAcceptStarR (Just 31)
+          cs `shouldSatisfy` isRight
+          fromRightS cs `shouldSatisfy` (\xs -> V.length xs > 30)

--- a/spec/GitHub/ActivitySpec.hs
+++ b/spec/GitHub/ActivitySpec.hs
@@ -3,8 +3,8 @@
 module GitHub.ActivitySpec where
 
 import GitHub.Auth                        (Auth (..))
-import GitHub.Endpoints.Activity.Watching (watchersForR)
 import GitHub.Endpoints.Activity.Starring (myStarredAcceptStarR)
+import GitHub.Endpoints.Activity.Watching (watchersForR)
 import GitHub.Request                     (executeRequest)
 
 import Data.Either.Compat (isRight)

--- a/spec/GitHub/ActivitySpec.hs
+++ b/spec/GitHub/ActivitySpec.hs
@@ -14,8 +14,6 @@ import Test.Hspec         (Spec, describe, it, pendingWith, shouldSatisfy)
 
 import qualified Data.Vector as V
 
-import GitHub.Data.Activities
-
 fromRightS :: Show a => Either a b -> b
 fromRightS (Right b) = b
 fromRightS (Left a) = error $ "Expected a Right and got a Left" ++ show a

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -26,6 +26,7 @@ module GitHub (
     stargazersForR,
     reposStarredByR,
     myStarredR,
+    myStarredAcceptStarR,
 
     -- ** Watching
     -- | See <https://developer.github.com/v3/activity/>

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -54,6 +54,7 @@ import Prelude.Compat
 import Data.Text (Text)
 
 import GitHub.Auth
+import GitHub.Data.Activities
 import GitHub.Data.Comments
 import GitHub.Data.Content
 import GitHub.Data.Definitions
@@ -67,7 +68,6 @@ import GitHub.Data.Repos
 import GitHub.Data.Request
 import GitHub.Data.Search
 import GitHub.Data.Teams
-import GitHub.Data.Activities
 import GitHub.Data.Webhooks
 
 mkOwnerId :: Int -> Id Owner

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -44,6 +44,7 @@ module GitHub.Data (
     module GitHub.Data.Request,
     module GitHub.Data.Search,
     module GitHub.Data.Teams,
+    module GitHub.Data.Activities,
     module GitHub.Data.Webhooks,
     ) where
 
@@ -66,6 +67,7 @@ import GitHub.Data.Repos
 import GitHub.Data.Request
 import GitHub.Data.Search
 import GitHub.Data.Teams
+import GitHub.Data.Activities
 import GitHub.Data.Webhooks
 
 mkOwnerId :: Int -> Id Owner

--- a/src/GitHub/Data/Activities.hs
+++ b/src/GitHub/Data/Activities.hs
@@ -16,14 +16,14 @@ import Control.DeepSeq.Generics (genericRnf)
 import Data.Aeson.Compat        (FromJSON (..), withObject, (.:))
 import Data.Binary              (Binary)
 import Data.Data                (Data, Typeable)
-import GHC.Generics             (Generic)
 import Data.Time                (UTCTime)
+import GHC.Generics             (Generic)
 
 import GitHub.Data.Repos (Repo)
 
 data RepoStarred = RepoStarred {
-   repoStarredStarredAt     :: !UTCTime
-  ,repoStarredRepo :: !Repo
+   repoStarredStarredAt :: !UTCTime
+  ,repoStarredRepo      :: !Repo
 } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
 instance NFData RepoStarred where rnf = genericRnf
@@ -31,7 +31,7 @@ instance Binary RepoStarred
 
 -- JSON Instances
 instance FromJSON RepoStarred where
-  parseJSON = withObject "RepoStarred" $ \o ->
-    RepoStarred <$> o .: "starred_at"
-               <*> o .: "repo"
+    parseJSON = withObject "RepoStarred" $ \o -> RepoStarred
+        <$> o .: "starred_at"
+        <*> o .: "repo"
 

--- a/src/GitHub/Data/Activities.hs
+++ b/src/GitHub/Data/Activities.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+module GitHub.Data.Activities where
+
+import Prelude        ()
+import Prelude.Compat
+
+import Control.DeepSeq          (NFData (..))
+import Control.DeepSeq.Generics (genericRnf)
+import Data.Aeson.Compat        (FromJSON (..), withObject, (.:))
+import Data.Binary              (Binary)
+import Data.Data                (Data, Typeable)
+import GHC.Generics             (Generic)
+import Data.Time                (UTCTime)
+
+import GitHub.Data.Repos (Repo)
+
+data RepoStarred = RepoStarred {
+   repoStarredStarredAt     :: !UTCTime
+  ,repoStarredRepo :: !Repo
+} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData RepoStarred where rnf = genericRnf
+instance Binary RepoStarred
+
+-- JSON Instances
+instance FromJSON RepoStarred where
+  parseJSON = withObject "RepoStarred" $ \o ->
+    RepoStarred <$> o .: "starred_at"
+               <*> o .: "repo"
+

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -33,8 +33,8 @@ import GHC.Generics      (Generic)
 import qualified Data.ByteString           as BS
 import qualified Data.ByteString.Lazy      as LBS
 import qualified Data.Text                 as T
+import qualified Network.HTTP.Types        as Types
 import qualified Network.HTTP.Types.Method as Method
-import qualified Network.HTTP.Types as Types
 
 import GitHub.Data.Id   (Id, untagId)
 import GitHub.Data.Name (Name, untagName)

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -34,6 +34,7 @@ import qualified Data.ByteString           as BS
 import qualified Data.ByteString.Lazy      as LBS
 import qualified Data.Text                 as T
 import qualified Network.HTTP.Types.Method as Method
+import qualified Network.HTTP.Types as Types
 
 import GitHub.Data.Id   (Id, untagId)
 import GitHub.Data.Name (Name, untagName)
@@ -122,6 +123,7 @@ data Request (k :: Bool) a where
     PagedQuery   :: FromJSON (Vector a) => Paths -> QueryString -> Maybe Count -> Request k (Vector a)
     Command      :: FromJSON a => CommandMethod a -> Paths -> LBS.ByteString -> Request 'True a
     StatusQuery  :: StatusMap a -> Request k () -> Request k a
+    HeaderQuery  :: FromJSON a => Types.RequestHeaders -> Request k a -> Request k a
     deriving (Typeable)
 
 deriving instance Eq (Request k a)
@@ -153,6 +155,12 @@ instance Show (Request k a) where
                     . showsPrec (appPrec + 1) m
                     . showString " "
                     . showsPrec (appPrec + 1) req
+            HeaderQuery m req -> showParen (d > appPrec) $
+                showString "Header "
+                    . showsPrec (appPrec + 1) m
+                    . showString " "
+                    . showsPrec (appPrec + 1) req
+
       where appPrec = 10 :: Int
 
 instance Hashable (Request k a) where
@@ -173,4 +181,8 @@ instance Hashable (Request k a) where
     hashWithSalt salt (StatusQuery sm req) =
         salt `hashWithSalt` (3 :: Int)
              `hashWithSalt` sm
+             `hashWithSalt` req
+    hashWithSalt salt (HeaderQuery h req) =
+        salt `hashWithSalt` (4 :: Int)
+             `hashWithSalt` h
              `hashWithSalt` req

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -123,7 +123,7 @@ data Request (k :: Bool) a where
     PagedQuery   :: FromJSON (Vector a) => Paths -> QueryString -> Maybe Count -> Request k (Vector a)
     Command      :: FromJSON a => CommandMethod a -> Paths -> LBS.ByteString -> Request 'True a
     StatusQuery  :: StatusMap a -> Request k () -> Request k a
-    HeaderQuery  :: FromJSON a => Types.RequestHeaders -> Request k a -> Request k a
+    HeaderQuery  :: Types.RequestHeaders -> Request k a -> Request k a
     deriving (Typeable)
 
 deriving instance Eq (Request k a)

--- a/src/GitHub/Endpoints/Activity/Starring.hs
+++ b/src/GitHub/Endpoints/Activity/Starring.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
 -- License     :  BSD-3-Clause

--- a/src/GitHub/Endpoints/Activity/Starring.hs
+++ b/src/GitHub/Endpoints/Activity/Starring.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings   #-}
 -----------------------------------------------------------------------------
 -- |
 -- License     :  BSD-3-Clause
@@ -13,6 +14,8 @@ module GitHub.Endpoints.Activity.Starring (
     reposStarredByR,
     myStarred,
     myStarredR,
+    myStarredAcceptStar,
+    myStarredAcceptStarR,
     module GitHub.Data,
     ) where
 
@@ -55,3 +58,13 @@ myStarred auth =
 -- | All the repos starred by the authenticated user.
 myStarredR :: Maybe Count -> Request 'True (Vector Repo)
 myStarredR = PagedQuery ["user", "starred"] []
+
+
+-- | All the repos starred by the authenticated user.
+myStarredAcceptStar :: Auth -> IO (Either Error (Vector RepoStarred))
+myStarredAcceptStar auth =
+    executeRequest auth $ myStarredAcceptStarR Nothing
+
+-- | All the repos starred by the authenticated user.
+myStarredAcceptStarR :: Maybe Count -> Request 'True (Vector RepoStarred)
+myStarredAcceptStarR mc = HeaderQuery [("Accept", "application/vnd.github.v3.star+json")] $ PagedQuery ["user", "starred"] [] mc

--- a/src/GitHub/Endpoints/Activity/Starring.hs
+++ b/src/GitHub/Endpoints/Activity/Starring.hs
@@ -56,6 +56,7 @@ myStarred auth =
     executeRequest auth $ myStarredR Nothing
 
 -- | All the repos starred by the authenticated user.
+-- See <https://developer.github.com/v3/activity/starring/#list-repositories-being-starred>
 myStarredR :: Maybe Count -> Request 'True (Vector Repo)
 myStarredR = PagedQuery ["user", "starred"] []
 
@@ -66,5 +67,6 @@ myStarredAcceptStar auth =
     executeRequest auth $ myStarredAcceptStarR Nothing
 
 -- | All the repos starred by the authenticated user.
+-- See <https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps-1>
 myStarredAcceptStarR :: Maybe Count -> Request 'True (Vector RepoStarred)
-myStarredAcceptStarR mc = HeaderQuery [("Accept", "application/vnd.github.v3.star+json")] $ PagedQuery ["user", "starred"] [] mc
+myStarredAcceptStarR = HeaderQuery [("Accept", "application/vnd.github.v3.star+json")] . PagedQuery ["user", "starred"] []

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -114,6 +114,7 @@ executeRequestWithMgr :: Manager
 executeRequestWithMgr mgr auth req = runExceptT $
     execute req
   where
+    execute :: Request k a -> ExceptT Error IO a
     execute req' = case req' of
         Query {} -> do
             httpReq <- makeHttpRequest (Just auth) req
@@ -155,7 +156,8 @@ executeRequestWithMgr' :: Manager
                        -> IO (Either Error a)
 executeRequestWithMgr' mgr req = runExceptT $
     execute req                                
-  where 
+  where
+    execute :: Request k a -> ExceptT Error IO a
     execute req' = case req' of
         Query {} -> do
             httpReq <- makeHttpRequest Nothing req
@@ -233,7 +235,7 @@ makeHttpRequest auth r = case r of
                $ req
     HeaderQuery h req -> do
         req' <- makeHttpRequest auth req
-        return $ req' { requestHeaders = h <> requestHeaders req'}
+        return $ req' { requestHeaders = h <> requestHeaders req' }
   where
     url :: Paths -> String
     url paths = baseUrl ++ '/' : intercalate "/" paths

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -155,7 +155,7 @@ executeRequestWithMgr' :: Manager
                        -> Request 'False a
                        -> IO (Either Error a)
 executeRequestWithMgr' mgr req = runExceptT $
-    execute req                                
+    execute req
   where
     execute :: Request k a -> ExceptT Error IO a
     execute req' = case req' of


### PR DESCRIPTION
#198 
I Added `HeaderQuery` in order to customize Accept Header.

For Example, it is needed to get `starred_at` of "List repositories being starred".
https://developer.github.com/v3/activity/starring/#list-repositories-being-starred.