### PR TITLE
Add deploy key API wrapper

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -83,6 +83,7 @@ Library
     GitHub.Data.Teams
     GitHub.Data.Activities
     GitHub.Data.URL
+    GitHub.Data.DeployKeys
     GitHub.Data.Webhooks
     GitHub.Data.Webhooks.Validate
     GitHub.Endpoints.Activity.Starring
@@ -109,6 +110,7 @@ Library
     GitHub.Endpoints.Repos.Commits
     GitHub.Endpoints.Repos.Forks
     GitHub.Endpoints.Repos.Webhooks
+    GitHub.Endpoints.Repos.DeployKeys
     GitHub.Endpoints.Search
     GitHub.Endpoints.Users
     GitHub.Endpoints.Users.Followers

--- a/samples/Repos/DeployKeys/CreateDeployKey.hs
+++ b/samples/Repos/DeployKeys/CreateDeployKey.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import GitHub.Data.Id (Id (..))
+import qualified GitHub.Data.DeployKeys as DK
+import qualified GitHub.Endpoints.Repos.DeployKeys as DK
+import qualified GitHub.Auth as Auth
+import Data.List
+import Data.Text (Text)
+
+main :: IO ()
+main = do
+  let auth = Auth.OAuth "auth_token"
+  eDeployKey <- DK.createRepoDeployKey' auth "your_owner" "your_repo" newDeployKey
+  case eDeployKey of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right deployKey) -> putStrLn $ show deployKey
+
+newDeployKey :: DK.NewRepoDeployKey
+newDeployKey = DK.NewRepoDeployKey publicKey "test-key" True
+  where
+    publicKey :: Text
+    publicKey = "your_public_key"

--- a/samples/Repos/DeployKeys/DeleteDeployKey.hs
+++ b/samples/Repos/DeployKeys/DeleteDeployKey.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import GitHub.Data.Id (Id (..))
+import qualified GitHub.Endpoints.Repos.DeployKeys as DK
+import qualified GitHub.Auth as Auth
+
+main :: IO ()
+main = do
+  let auth = Auth.OAuth "auth_token"
+  eDeployKey <- DK.deleteRepoDeployKey' auth "your_owner" "your_repo" (Id 18530161)
+  case eDeployKey of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right _) -> putStrLn $ "Deleted deploy key!"

--- a/samples/Repos/DeployKeys/ListDeployKeys.hs
+++ b/samples/Repos/DeployKeys/ListDeployKeys.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import qualified GitHub.Data.DeployKeys as DK
+import qualified GitHub.Endpoints.Repos.DeployKeys as DK
+import qualified GitHub.Auth as Auth
+import Data.List
+import Data.Vector (toList)
+
+main :: IO ()
+main = do
+  let auth = Auth.OAuth "auth_token"
+  eDeployKeys <- DK.deployKeysFor' auth "your_owner" "your_repo"
+  case eDeployKeys of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right deployKeys) -> putStrLn $ intercalate "\n" $ map formatRepoDeployKey (toList deployKeys)
+
+formatRepoDeployKey :: DK.RepoDeployKey -> String
+formatRepoDeployKey = show
+

--- a/samples/Repos/DeployKeys/ShowDeployKey.hs
+++ b/samples/Repos/DeployKeys/ShowDeployKey.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import GitHub.Data.Id (Id (..))
+import qualified GitHub.Data.DeployKeys as DK
+import qualified GitHub.Endpoints.Repos.DeployKeys as DK
+import qualified GitHub.Auth as Auth
+
+main :: IO ()
+main = do
+  let auth = Auth.OAuth "auth_token"
+  eDeployKey <- DK.deployKeyFor' auth "your_owner" "your_repo" (Id 18528451)
+  case eDeployKey of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right deployKey) -> putStrLn $ formatRepoDeployKey deployKey
+
+formatRepoDeployKey :: DK.RepoDeployKey -> String
+formatRepoDeployKey = show
+
+

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -80,6 +80,40 @@ executable github-operational
     , transformers-compat
   default-language: Haskell2010
 
+executable github-show-deploy-key
+  main-is: ShowDeployKey.hs
+  hs-source-dirs:
+      Repos/DeployKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  other-modules:
+      CreateDeployKey
+      DeleteDeployKey
+      ListDeployKeys
+  default-language: Haskell2010
+
+executable github-delete-deploy-key
+  main-is: DeleteDeployKey.hs
+  hs-source-dirs:
+      Repos/DeployKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  other-modules:
+      CreateDeployKey
+      ListDeployKeys
+      ShowDeployKey
+  default-language: Haskell2010
+
 executable github-list-team-repos
   main-is: ListRepos.hs
   hs-source-dirs:
@@ -120,6 +154,24 @@ executable github-delete-team
       Memberships.DeleteTeamMembershipFor
       Memberships.TeamMembershipInfoFor
       TeamInfoFor
+  default-language: Haskell2010
+
+executable github-list-deploy-keys-for
+  main-is: ListDeployKeys.hs
+  hs-source-dirs:
+      Repos/DeployKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+    , vector
+  other-modules:
+      CreateDeployKey
+      DeleteDeployKey
+      ShowDeployKey
   default-language: Haskell2010
 
 executable github-delete-team-membership-for
@@ -203,6 +255,23 @@ executable github-list-followers-example
   other-modules:
       ListFollowers
       ListFollowing
+  default-language: Haskell2010
+
+executable github-create-deploy-key
+  main-is: CreateDeployKey.hs
+  hs-source-dirs:
+      Repos/DeployKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  other-modules:
+      DeleteDeployKey
+      ListDeployKeys
+      ShowDeployKey
   default-language: Haskell2010
 
 executable github-add-team-membership-for

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.9.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -20,10 +20,10 @@ library
       Common
   default-language: Haskell2010
 
-executable github-add-team-membership-for
-  main-is: AddTeamMembershipFor.hs
+executable github-edit-team
+  main-is: EditTeam.hs
   hs-source-dirs:
-      Teams/Memberships
+      Teams
   ghc-options: -Wall
   build-depends:
       base
@@ -32,8 +32,73 @@ executable github-add-team-membership-for
     , text
     , github-samples
   other-modules:
-      DeleteTeamMembershipFor
-      TeamMembershipInfoFor
+      DeleteTeam
+      ListRepos
+      ListTeamsCurrent
+      Memberships.AddTeamMembershipFor
+      Memberships.DeleteTeamMembershipFor
+      Memberships.TeamMembershipInfoFor
+      TeamInfoFor
+  default-language: Haskell2010
+
+executable github-list-team-current
+  main-is: ListTeamsCurrent.hs
+  hs-source-dirs:
+      Teams
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  other-modules:
+      DeleteTeam
+      EditTeam
+      ListRepos
+      Memberships.AddTeamMembershipFor
+      Memberships.DeleteTeamMembershipFor
+      Memberships.TeamMembershipInfoFor
+      TeamInfoFor
+  default-language: Haskell2010
+
+executable github-operational
+  main-is: Operational.hs
+  hs-source-dirs:
+      Operational
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+    , http-client
+    , http-client-tls
+    , operational
+    , transformers
+    , transformers-compat
+  default-language: Haskell2010
+
+executable github-list-team-repos
+  main-is: ListRepos.hs
+  hs-source-dirs:
+      Teams
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  other-modules:
+      DeleteTeam
+      EditTeam
+      ListTeamsCurrent
+      Memberships.AddTeamMembershipFor
+      Memberships.DeleteTeamMembershipFor
+      Memberships.TeamMembershipInfoFor
+      TeamInfoFor
   default-language: Haskell2010
 
 executable github-delete-team
@@ -73,10 +138,10 @@ executable github-delete-team-membership-for
       TeamMembershipInfoFor
   default-language: Haskell2010
 
-executable github-edit-team
-  main-is: EditTeam.hs
+executable github-show-user-2
+  main-is: ShowUser2.hs
   hs-source-dirs:
-      Teams
+      Users
   ghc-options: -Wall
   build-depends:
       base
@@ -85,120 +150,10 @@ executable github-edit-team
     , text
     , github-samples
   other-modules:
-      DeleteTeam
-      ListRepos
-      ListTeamsCurrent
-      Memberships.AddTeamMembershipFor
-      Memberships.DeleteTeamMembershipFor
-      Memberships.TeamMembershipInfoFor
-      TeamInfoFor
-  default-language: Haskell2010
-
-executable github-list-followers
-  main-is: ListFollowers.hs
-  hs-source-dirs:
-      Users/Followers
-  ghc-options: -Wall
-  build-depends:
-      base
-    , base-compat
-    , github
-    , text
-    , github-samples
-  other-modules:
-      Example
-      ListFollowing
-  default-language: Haskell2010
-
-executable github-list-followers-example
-  main-is: Example.hs
-  hs-source-dirs:
-      Users/Followers
-  ghc-options: -Wall
-  build-depends:
-      base
-    , base-compat
-    , github
-    , text
-  other-modules:
-      ListFollowers
-      ListFollowing
-  default-language: Haskell2010
-
-executable github-list-following
-  main-is: ListFollowing.hs
-  hs-source-dirs:
-      Users/Followers
-  ghc-options: -Wall
-  build-depends:
-      base
-    , base-compat
-    , github
-    , text
-    , github-samples
-  other-modules:
-      Example
-      ListFollowers
-  default-language: Haskell2010
-
-executable github-list-team-current
-  main-is: ListTeamsCurrent.hs
-  hs-source-dirs:
-      Teams
-  ghc-options: -Wall
-  build-depends:
-      base
-    , base-compat
-    , github
-    , text
-    , github-samples
-  other-modules:
-      DeleteTeam
-      EditTeam
-      ListRepos
-      Memberships.AddTeamMembershipFor
-      Memberships.DeleteTeamMembershipFor
-      Memberships.TeamMembershipInfoFor
-      TeamInfoFor
-  default-language: Haskell2010
-
-executable github-list-team-repos
-  main-is: ListRepos.hs
-  hs-source-dirs:
-      Teams
-  ghc-options: -Wall
-  build-depends:
-      base
-    , base-compat
-    , github
-    , text
-    , github-samples
-  other-modules:
-      DeleteTeam
-      EditTeam
-      ListTeamsCurrent
-      Memberships.AddTeamMembershipFor
-      Memberships.DeleteTeamMembershipFor
-      Memberships.TeamMembershipInfoFor
-      TeamInfoFor
-  default-language: Haskell2010
-
-executable github-operational
-  main-is: Operational.hs
-  hs-source-dirs:
-      Operational
-  ghc-options: -Wall
-  build-depends:
-      base
-    , base-compat
-    , github
-    , text
-    , github-samples
-    , http-client
-    , http-client-tls
-    , operational
-    , transformers
-    , transformers-compat
+      Followers.Example
+      Followers.ListFollowers
+      Followers.ListFollowing
+      ShowUser
   default-language: Haskell2010
 
 executable github-show-user
@@ -219,10 +174,10 @@ executable github-show-user
       ShowUser2
   default-language: Haskell2010
 
-executable github-show-user-2
-  main-is: ShowUser2.hs
+executable github-list-following
+  main-is: ListFollowing.hs
   hs-source-dirs:
-      Users
+      Users/Followers
   ghc-options: -Wall
   build-depends:
       base
@@ -231,10 +186,39 @@ executable github-show-user-2
     , text
     , github-samples
   other-modules:
-      Followers.Example
-      Followers.ListFollowers
-      Followers.ListFollowing
-      ShowUser
+      Example
+      ListFollowers
+  default-language: Haskell2010
+
+executable github-list-followers-example
+  main-is: Example.hs
+  hs-source-dirs:
+      Users/Followers
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+  other-modules:
+      ListFollowers
+      ListFollowing
+  default-language: Haskell2010
+
+executable github-add-team-membership-for
+  main-is: AddTeamMembershipFor.hs
+  hs-source-dirs:
+      Teams/Memberships
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  other-modules:
+      DeleteTeamMembershipFor
+      TeamMembershipInfoFor
   default-language: Haskell2010
 
 executable github-team-membership-info-for
@@ -251,6 +235,22 @@ executable github-team-membership-info-for
   other-modules:
       AddTeamMembershipFor
       DeleteTeamMembershipFor
+  default-language: Haskell2010
+
+executable github-list-followers
+  main-is: ListFollowers.hs
+  hs-source-dirs:
+      Users/Followers
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  other-modules:
+      Example
+      ListFollowing
   default-language: Haskell2010
 
 executable github-teaminfo-for

--- a/samples/package.yaml
+++ b/samples/package.yaml
@@ -85,3 +85,24 @@ executables:
       - operational
       - transformers
       - transformers-compat
+  github-list-deploy-keys-for:
+    main: ListDeployKeys.hs
+    source-dirs: Repos/DeployKeys
+    dependencies:
+      - github-samples
+      - vector
+  github-show-deploy-key:
+    main: ShowDeployKey.hs
+    source-dirs: Repos/DeployKeys
+    dependencies:
+      - github-samples
+  github-create-deploy-key:
+    main: CreateDeployKey.hs
+    source-dirs: Repos/DeployKeys
+    dependencies:
+      - github-samples
+  github-delete-deploy-key:
+    main: DeleteDeployKey.hs
+    source-dirs: Repos/DeployKeys
+    dependencies:
+      - github-samples

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -35,6 +35,7 @@ module GitHub.Data (
     module GitHub.Data.Comments,
     module GitHub.Data.Content,
     module GitHub.Data.Definitions,
+    module GitHub.Data.DeployKeys,
     module GitHub.Data.Gists,
     module GitHub.Data.GitData,
     module GitHub.Data.Issues,
@@ -44,7 +45,7 @@ module GitHub.Data (
     module GitHub.Data.Search,
     module GitHub.Data.Teams,
     module GitHub.Data.URL,
-    module GitHub.Data.Webhooks,
+    module GitHub.Data.Webhooks
     ) where
 
 import GitHub.Internal.Prelude
@@ -54,6 +55,7 @@ import GitHub.Data.Activities
 import GitHub.Data.Comments
 import GitHub.Data.Content
 import GitHub.Data.Definitions
+import GitHub.Data.DeployKeys
 import GitHub.Data.Gists
 import GitHub.Data.GitData
 import GitHub.Data.Id

--- a/src/GitHub/Data/DeployKeys.hs
+++ b/src/GitHub/Data/DeployKeys.hs
@@ -28,3 +28,23 @@ instance FromJSON RepoDeployKey where
                   <*> o .: "verified"
                   <*> o .: "created_at"
                   <*> o .: "read_only"
+
+data NewRepoDeployKey = NewRepoDeployKey {
+   newRepoDeployKeyKey          :: !Text
+  ,newRepoDeployKeyTitle        :: !Text
+  ,newRepoDeployKeyReadOnly     :: !Bool
+} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance ToJSON NewRepoDeployKey where
+  toJSON (NewRepoDeployKey key title readOnly) =
+    object [
+      "key" .= key
+    , "title" .= title
+    , "read_only" .= readOnly
+    ]
+
+instance FromJSON NewRepoDeployKey where
+  parseJSON = withObject "RepoDeployKey" $ \o ->
+    NewRepoDeployKey <$> o .: "key"
+                     <*> o .: "title"
+                     <*> o .: "read_only"

--- a/src/GitHub/Data/DeployKeys.hs
+++ b/src/GitHub/Data/DeployKeys.hs
@@ -1,0 +1,30 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Todd Mohney <toddmohney@gmail.com>
+--
+module GitHub.Data.DeployKeys where
+
+import GitHub.Data.Id          (Id)
+import GitHub.Data.URL         (URL)
+import GitHub.Internal.Prelude
+
+data RepoDeployKey = RepoDeployKey {
+   repoDeployKeyId           :: !(Id RepoDeployKey)
+  ,repoDeployKeyKey          :: !Text
+  ,repoDeployKeyUrl          :: !URL
+  ,repoDeployKeyTitle        :: !Text
+  ,repoDeployKeyVerified     :: !Bool
+  ,repoDeployKeyCreatedAt    :: !UTCTime
+  ,repoDeployKeyReadOnly     :: !Bool
+} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance FromJSON RepoDeployKey where
+  parseJSON = withObject "RepoDeployKey" $ \o ->
+    RepoDeployKey <$> o .: "id"
+                  <*> o .: "key"
+                  <*> o .: "url"
+                  <*> o .: "title"
+                  <*> o .: "verified"
+                  <*> o .: "created_at"
+                  <*> o .: "read_only"

--- a/src/GitHub/Endpoints/Repos/DeployKeys.hs
+++ b/src/GitHub/Endpoints/Repos/DeployKeys.hs
@@ -11,13 +11,21 @@ module GitHub.Endpoints.Repos.DeployKeys (
     deployKeysForR,
     deployKeyFor',
     deployKeyForR,
+
+    -- ** Create
+    createRepoDeployKey',
+    createRepoDeployKeyR,
+
+    -- ** Delete
+    deleteRepoDeployKey',
+    deleteRepoDeployKeyR,
 ) where
 
 import GitHub.Data
 import GitHub.Request
 import GitHub.Internal.Prelude
 
--- * Querying deploy keys
+-- | Querying deploy keys
 deployKeysFor' :: Auth -> Name Owner -> Name Repo -> IO (Either Error (Vector RepoDeployKey))
 deployKeysFor' auth user repo =
     executeRequest auth $ deployKeysForR user repo FetchAll
@@ -26,6 +34,7 @@ deployKeysForR :: Name Owner -> Name Repo -> FetchCount -> Request k (Vector Rep
 deployKeysForR user repo =
     PagedQuery ["repos", toPathPart user, toPathPart repo, "keys"] []
 
+-- | Querying a deploy key
 deployKeyFor' :: Auth -> Name Owner -> Name Repo -> Id RepoDeployKey -> IO (Either Error RepoDeployKey)
 deployKeyFor' auth user repo keyId =
     executeRequest auth $ deployKeyForR user repo keyId
@@ -33,3 +42,23 @@ deployKeyFor' auth user repo keyId =
 deployKeyForR :: Name Owner -> Name Repo -> Id RepoDeployKey -> Request k RepoDeployKey
 deployKeyForR user repo keyId =
     Query ["repos", toPathPart user, toPathPart repo, "keys", toPathPart keyId] []
+
+-- | Create a deploy key
+createRepoDeployKey' :: Auth -> Name Owner -> Name Repo -> NewRepoDeployKey -> IO (Either Error RepoDeployKey)
+createRepoDeployKey' auth user repo key =
+    executeRequest auth $ createRepoDeployKeyR user repo key
+
+-- | Create a deploy key.
+createRepoDeployKeyR :: Name Owner -> Name Repo -> NewRepoDeployKey -> Request 'True RepoDeployKey
+createRepoDeployKeyR user repo key =
+    Command Post ["repos", toPathPart user, toPathPart repo, "keys"] (encode key)
+
+deleteRepoDeployKey' :: Auth -> Name Owner -> Name Repo -> Id RepoDeployKey -> IO (Either Error ())
+deleteRepoDeployKey' auth user repo keyId =
+    executeRequest auth $ deleteRepoDeployKeyR user repo keyId
+
+-- | Delete a deploy key.
+-- See <https://developer.github.com/v3/repos/keys/#remove-a-deploy-key>
+deleteRepoDeployKeyR :: Name Owner -> Name Repo -> Id RepoDeployKey -> Request 'True ()
+deleteRepoDeployKeyR user repo keyId =
+    Command Delete ["repos", toPathPart user, toPathPart repo, "keys", toPathPart keyId] mempty

--- a/src/GitHub/Endpoints/Repos/DeployKeys.hs
+++ b/src/GitHub/Endpoints/Repos/DeployKeys.hs
@@ -1,0 +1,35 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Todd Mohney <toddmohney@gmail.com>
+--
+-- The deploy keys API, as described at
+-- <https://developer.github.com/v3/repos/keys>
+module GitHub.Endpoints.Repos.DeployKeys (
+    -- * Querying deploy keys
+    deployKeysFor',
+    deployKeysForR,
+    deployKeyFor',
+    deployKeyForR,
+) where
+
+import GitHub.Data
+import GitHub.Request
+import GitHub.Internal.Prelude
+
+-- * Querying deploy keys
+deployKeysFor' :: Auth -> Name Owner -> Name Repo -> IO (Either Error (Vector RepoDeployKey))
+deployKeysFor' auth user repo =
+    executeRequest auth $ deployKeysForR user repo FetchAll
+
+deployKeysForR :: Name Owner -> Name Repo -> FetchCount -> Request k (Vector RepoDeployKey)
+deployKeysForR user repo =
+    PagedQuery ["repos", toPathPart user, toPathPart repo, "keys"] []
+
+deployKeyFor' :: Auth -> Name Owner -> Name Repo -> Id RepoDeployKey -> IO (Either Error RepoDeployKey)
+deployKeyFor' auth user repo keyId =
+    executeRequest auth $ deployKeyForR user repo keyId
+
+deployKeyForR :: Name Owner -> Name Repo -> Id RepoDeployKey -> Request k RepoDeployKey
+deployKeyForR user repo keyId =
+    Query ["repos", toPathPart user, toPathPart repo, "keys", toPathPart keyId] []


### PR DESCRIPTION
Implement API wrapper functions for GitHub's [deploy key](https://developer.github.com/v3/repos/keys/) endpoints

Adds functions for:
- creating a new deploy key
- listing all deploy keys
- showing a deploy key by ID
- deleting a deploy key

(GitHub does not support editing a deploy key at this time)