### PR TITLE
Resolve warning regarding parseUrlThrow

### DIFF
--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -66,8 +66,13 @@ import Data.List                  (find)
 import Network.HTTP.Client          (CookieJar, HttpException (..), Manager,
                                      RequestBody (..), Response (..),
                                      applyBasicAuth, checkStatus, httpLbs,
-                                     method, newManager, parseUrl, requestBody,
+                                     method, newManager, requestBody,
                                      requestHeaders, setQueryString)
+#if MIN_VERSION_http_client(0,4,30)
+import Network.HTTP.Client          (parseUrlThrow)
+#else
+import Network.HTTP.Client          (parseUrl)
+#endif
 import Network.HTTP.Client.Internal (setUri)
 import Network.HTTP.Client.TLS      (tlsManagerSettings)
 import Network.HTTP.Link.Parser     (parseLinkHeaderBS)
@@ -233,7 +238,11 @@ makeHttpRequest auth r = case r of
         return $ req' { requestHeaders = h <> requestHeaders req' }
   where
     parseUrl' :: MonadThrow m => Text -> m HTTP.Request
+#if MIN_VERSION_http_client(0,4,30)
+    parseUrl' = parseUrlThrow . T.unpack
+#else
     parseUrl' = parseUrl . T.unpack
+#endif
 
     url :: Paths -> Text
     url paths = baseUrl <> "/" <> T.intercalate "/" paths


### PR DESCRIPTION
The http-client library introduced a new name for `parseUrl` in version 0.4.30,
`parseUrlThrow`, and deprecated the use of `parseUrl`. This causes a warning
during compilation. Since we support http-client above `0.4.8.1`, I have added
some additional CPP conditional compilation to import and use `parseUrl` for
older versions of http-client, and to import and use `parseUrlThrow` in the
newer versions.