### PR TITLE
Adding support for the 'Add or update team repository' github API.

### DIFF
--- a/samples/Teams/Repos/AddOrUpdateTeamRepo.hs
+++ b/samples/Teams/Repos/AddOrUpdateTeamRepo.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import Common
+
+import qualified GitHub
+import qualified GitHub.Endpoints.Organizations.Teams as GitHub
+
+main :: IO ()
+main = do
+  args <- getArgs
+  result <- case args of
+              [token, team_id, org, repo] ->
+                 GitHub.addOrUpdateTeamRepo'
+                    (GitHub.OAuth $ fromString token)
+                    (GitHub.mkTeamId $ read team_id)
+                    (GitHub.mkOrganizationName $ fromString org)
+                    (GitHub.mkRepoName $ fromString repo)
+                    GitHub.PermissionPull
+              _                          ->
+                error "usage: AddOrUpdateTeamRepo <token> <team_id> <org> <repo>"
+  case result of
+    Left err   -> putStrLn $ "Error: " <> tshow err
+    Right team -> putStrLn $ tshow team

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -56,6 +56,7 @@ data CommandMethod a where
     Post   :: CommandMethod a
     Patch  :: CommandMethod a
     Put    :: CommandMethod a
+    Put'   :: CommandMethod ()
     Delete :: CommandMethod ()
     deriving (Typeable)
 
@@ -65,18 +66,21 @@ instance Show (CommandMethod a) where
     showsPrec _ Post    = showString "Post"
     showsPrec _ Patch   = showString "Patch"
     showsPrec _ Put     = showString "Put"
+    showsPrec _ Put'     = showString "Put'"
     showsPrec _ Delete  = showString "Delete"
 
 instance Hashable (CommandMethod a) where
     hashWithSalt salt Post    = hashWithSalt salt (0 :: Int)
     hashWithSalt salt Patch   = hashWithSalt salt (1 :: Int)
     hashWithSalt salt Put     = hashWithSalt salt (2 :: Int)
-    hashWithSalt salt Delete  = hashWithSalt salt (3 :: Int)
+    hashWithSalt salt Put'    = hashWithSalt salt (3 :: Int)
+    hashWithSalt salt Delete  = hashWithSalt salt (4 :: Int)
 
 toMethod :: CommandMethod a -> Method.Method
 toMethod Post   = Method.methodPost
 toMethod Patch  = Method.methodPatch
 toMethod Put    = Method.methodPut
+toMethod Put'   = Method.methodPut
 toMethod Delete = Method.methodDelete
 
 -- | 'PagedQuery' returns just some results, using this data we can specify how

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -34,6 +34,13 @@ data Permission =
 instance NFData Permission where rnf = genericRnf
 instance Binary Permission
 
+data AddTeamRepoPermission = AddTeamRepoPermission {
+  addTeamRepoPermission :: !Permission
+} deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData AddTeamRepoPermission where rnf = genericRnf
+instance Binary AddTeamRepoPermission
+
 data SimpleTeam = SimpleTeam {
    simpleTeamId              :: !(Id Team)
   ,simpleTeamUrl             :: !URL
@@ -177,6 +184,14 @@ instance FromJSON CreateTeamMembership where
 instance ToJSON CreateTeamMembership where
   toJSON (CreateTeamMembership { createTeamMembershipRole = role }) =
     object [ "role" .= role ]
+
+instance FromJSON AddTeamRepoPermission where
+  parseJSON = withObject "AddTeamRepoPermission" $ \o ->
+    AddTeamRepoPermission <$> o .: "permission"
+
+instance ToJSON AddTeamRepoPermission where
+  toJSON (AddTeamRepoPermission { addTeamRepoPermission = permission}) =
+    object [ "permission" .= permission ]
 
 instance FromJSON Role where
   parseJSON (String attr) =

--- a/src/GitHub/Endpoints/Organizations/Teams.hs
+++ b/src/GitHub/Endpoints/Organizations/Teams.hs
@@ -22,6 +22,8 @@ module GitHub.Endpoints.Organizations.Teams (
     listTeamRepos,
     listTeamRepos',
     listTeamReposR,
+    addOrUpdateTeamRepo',
+    addOrUpdateTeamRepoR,
     teamMembershipInfoFor,
     teamMembershipInfoFor',
     teamMembershipInfoForR,
@@ -156,6 +158,19 @@ listTeamReposR tid  =
 -- > listTeamRepos (GitHub.mkTeamId team_id)
 listTeamRepos :: Id Team -> IO (Either Error (Vector Repo))
 listTeamRepos = listTeamRepos' Nothing
+
+-- | Add a repository to a team or update the permission on the repository.
+--
+-- > addOrUpdateTeamRepo' (OAuth "token") 1010101 "mburns" (Just PermissionPull)
+addOrUpdateTeamRepo' :: Auth -> Id Team -> Name Organization -> Name Repo -> Permission -> IO (Either Error ())
+addOrUpdateTeamRepo' auth tid org repo permission =
+    executeRequest auth $ addOrUpdateTeamRepoR tid org repo permission
+
+-- | Add or update a team repository.
+-- See <https://developer.github.com/v3/orgs/teams/#add-or-update-team-repository>
+addOrUpdateTeamRepoR :: Id Team -> Name Organization -> Name Repo -> Permission -> Request 'RW ()
+addOrUpdateTeamRepoR tid org repo permission =
+    command Put' ["teams", toPathPart tid, "repos", toPathPart org, toPathPart repo] (encode $ AddTeamRepoPermission permission)
 
 -- | Retrieve team mebership information for a user.
 -- With authentication

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -138,6 +138,7 @@ executeRequestWithMgr mgr auth req = runExceptT $ do
         res <- httpLbs' httpReq
         case m of
              Delete -> pure ()
+             Put'   -> pure ()
              _      -> parseResponse res
 
 


### PR DESCRIPTION
Hi @phadej, 

I've added support for this endpoint: https://developer.github.com/v3/orgs/teams/#add-or-update-team-repository

Let me know if there are any changes you would like me to make. I wasn't sure if my `Put'` type was the best way to add support for a "No-Content" Put request or not.
