### PR TITLE
pulls: Update base and maintainer_can_modify

### DIFF
--- a/samples/Pulls/UpdatePull.hs
+++ b/samples/Pulls/UpdatePull.hs
@@ -6,7 +6,13 @@ import Github.Data
 
 main :: IO ()
 main = do
-  mergeResult  <- Github.updatePullRequest (OAuth "authtoken") "repoOwner" "repoName" 22 (EditPullRequest { editPullRequestTitle = Just "Brand new title", editPullRequestBody = Nothing, editPullRequestState = Just EditPullRequestStateClosed })
+  mergeResult  <- Github.updatePullRequest (OAuth "authtoken") "repoOwner" "repoName" 22 EditPullRequest
+    { editPullRequestTitle = Just "Brand new title"
+    , editPullRequestBody = Nothing
+    , editPullRequestState = Just EditPullRequestStateClosed
+    , editPullRequestBase = Nothing
+    , editPullRequestMaintainerCanModify = Just True
+    }
   case mergeResult of
        (Left err) -> putStrLn $ "Error: " ++ (show err)
        (Right dpr) -> putStrLn . show $ dpr

--- a/src/GitHub/Data/PullRequests.hs
+++ b/src/GitHub/Data/PullRequests.hs
@@ -90,6 +90,9 @@ data EditPullRequest = EditPullRequest
     { editPullRequestTitle :: !(Maybe Text)
     , editPullRequestBody  :: !(Maybe Text)
     , editPullRequestState :: !(Maybe IssueState)
+    , editPullRequestBase  :: !(Maybe Text)
+    , editPullRequestMaintainerCanModify
+                           :: !(Maybe Bool)
     }
   deriving (Show, Generic)
 
@@ -198,8 +201,15 @@ instance FromJSON SimplePullRequest where
         <*> o .: "id"
 
 instance ToJSON EditPullRequest where
-    toJSON (EditPullRequest t b s) =
-        object $ filter notNull [ "title" .= t, "body" .= b, "state" .= s ]
+    toJSON (EditPullRequest t b s base mcm) =
+        object $ filter notNull
+            [ "title" .= t
+            , "body"  .= b
+            , "state" .= s
+            , "base"  .= base
+            , "maintainer_can_modify"
+                      .= mcm
+            ]
       where
         notNull (_, Null) = False
         notNull (_, _) = True


### PR DESCRIPTION
GitHub added support for changing the base branch for a pull request and
whether the maintainer can modify its contents or not. This adds the same to
the `updatePullRequest` API.