### PR TITLE
Add support for user public events.

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -173,6 +173,7 @@ test-suite github-test
     GitHub.ReposSpec
     GitHub.SearchSpec
     GitHub.UsersSpec
+    GitHub.EventsSpec
   main-is: Spec.hs
   ghc-options: -Wall
   build-depends: base,

--- a/spec/GitHub/EventsSpec.hs
+++ b/spec/GitHub/EventsSpec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+module GitHub.EventsSpec where
+
+import Data.Either        (isRight)
+import Data.String        (fromString)
+import Prelude ()
+import Prelude.Compat
+import System.Environment (lookupEnv)
+import Test.Hspec         (Spec, describe, it, shouldSatisfy,
+                           pendingWith)
+
+import qualified GitHub
+import GitHub.Data (Auth(..))
+
+fromRightS :: Show a => Either a b -> b
+fromRightS (Left xs) = error $ "Should be Right" ++ show xs
+fromRightS (Right xs) = xs
+
+withAuth :: (Auth -> IO ()) -> IO ()
+withAuth action = do
+  mtoken <- lookupEnv "GITHUB_TOKEN"
+  case mtoken of
+    Nothing    -> pendingWith "no GITHUB_TOKEN"
+    Just token -> action (OAuth $ fromString token)
+
+spec :: Spec
+spec = do
+  describe "repositoryEventsR" $ do
+    it "returns non empty list of events" $ shouldSucceed $
+      GitHub.repositoryEventsR "phadej" "github" 1
+  describe "userEventsR" $ do
+    it "returns non empty list of events" $ shouldSucceed $ GitHub.userEventsR "phadej" 1 
+  where shouldSucceed f = withAuth $ \auth -> do
+          cs <- GitHub.executeRequest auth $ f
+          cs `shouldSatisfy` isRight
+          length (fromRightS cs) `shouldSatisfy` (> 1)

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -18,7 +18,7 @@ module GitHub (
     -- ** Events
     -- | See https://developer.github.com/v3/activity/events/#events
     repositoryEventsR,
-
+    userEventsR,
     -- ** Starring
     -- | See <https://developer.github.com/v3/activity/starring/>
     --

--- a/src/GitHub/Endpoints/Activity/Events.hs
+++ b/src/GitHub/Endpoints/Activity/Events.hs
@@ -7,6 +7,7 @@
 module GitHub.Endpoints.Activity.Events (
     -- * Events
     repositoryEventsR,
+    userEventsR,
     module GitHub.Data,
     ) where
 
@@ -19,3 +20,9 @@ import Prelude ()
 repositoryEventsR :: Name Owner -> Name Repo -> FetchCount -> Request 'RO (Vector Event)
 repositoryEventsR user repo =
     pagedQuery  ["repos", toPathPart user, toPathPart repo, "events"] []
+
+-- | List user public events.
+-- See <https://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user>
+userEventsR :: Name User -> FetchCount -> Request 'RO (Vector Event)
+userEventsR user =
+    pagedQuery ["users", toPathPart user, "events", "public"] []


### PR DESCRIPTION
Implement improvement #273

This PR implements a get method as well as its associated tests for this endpoint: https://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user

Since the get repository events endpoint (https://developer.github.com/v3/activity/events/#list-repository-events) was quite similar and was missing integration tests, I took advantage of this PR to write some.

I tried to respect as much as I could your coding style regarding tests, hope I managed to do that right.

Please note that I am a beginner regarding haskell, do not hesitate to let me know if I can improve something. I will not be offended and glad to fix that!

Have a nice day!