### PR TITLE
Add support for pull request reviews

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -109,7 +109,7 @@ Library
     GitHub.Endpoints.Organizations.Teams
     GitHub.Endpoints.PullRequests
     GitHub.Endpoints.PullRequests.Reviews
-    GitHub.Endpoints.PullRequests.ReviewComments
+    GitHub.Endpoints.PullRequests.Comments
     GitHub.Endpoints.Repos
     GitHub.Endpoints.Repos.Collaborators
     GitHub.Endpoints.Repos.Comments

--- a/github.cabal
+++ b/github.cabal
@@ -84,6 +84,7 @@ Library
     GitHub.Data.Releases
     GitHub.Data.Repos
     GitHub.Data.Request
+    GitHub.Data.Reviews
     GitHub.Data.Search
     GitHub.Data.Teams
     GitHub.Data.URL
@@ -107,6 +108,7 @@ Library
     GitHub.Endpoints.Organizations.Members
     GitHub.Endpoints.Organizations.Teams
     GitHub.Endpoints.PullRequests
+    GitHub.Endpoints.PullRequests.Reviews
     GitHub.Endpoints.PullRequests.ReviewComments
     GitHub.Endpoints.Repos
     GitHub.Endpoints.Repos.Collaborators
@@ -172,6 +174,7 @@ test-suite github-test
     GitHub.OrganizationsSpec
     GitHub.IssuesSpec
     GitHub.PullRequestsSpec
+    GitHub.PullRequestReviewsSpec
     GitHub.ReleasesSpec
     GitHub.ReposSpec
     GitHub.SearchSpec

--- a/samples/Pulls/Comments/ListComments.hs
+++ b/samples/Pulls/Comments/ListComments.hs
@@ -1,6 +1,6 @@
 module ListComments where
 
-import qualified Github.PullRequests.ReviewComments as Github
+import qualified Github.PullRequests.Comments as Github
 import Data.List
 
 main = do

--- a/samples/Pulls/Comments/ShowComment.hs
+++ b/samples/Pulls/Comments/ShowComment.hs
@@ -1,4 +1,4 @@
-module ShowComments where
+module ShowComment where
 
 import qualified Github.PullRequests.ReviewComments as Github
 import Data.List

--- a/samples/Pulls/ReviewComments/ListComments.hs
+++ b/samples/Pulls/ReviewComments/ListComments.hs
@@ -4,7 +4,7 @@ import qualified Github.PullRequests.ReviewComments as Github
 import Data.List
 
 main = do
-  possiblePullRequestComments <- Github.pullRequestReviewComments "thoughtbot" "factory_girl" 256
+  possiblePullRequestComments <- Github.pullRequestComments "thoughtbot" "factory_girl" 256
   case possiblePullRequestComments of
        (Left error)     -> putStrLn $ "Error: " ++ (show error)
        (Right comments) -> putStrLn $ intercalate "\n\n" $ map formatComment comments

--- a/samples/Pulls/ReviewComments/ShowComment.hs
+++ b/samples/Pulls/ReviewComments/ShowComment.hs
@@ -4,7 +4,7 @@ import qualified Github.PullRequests.ReviewComments as Github
 import Data.List
 
 main = do
-  possiblePullRequestComment <- Github.pullRequestReviewComment "thoughtbot" "factory_girl" 301819
+  possiblePullRequestComment <- Github.pullRequestComment "thoughtbot" "factory_girl" 301819
   case possiblePullRequestComment of
        (Left error)     -> putStrLn $ "Error: " ++ (show error)
        (Right comment) -> putStrLn $ formatComment comment

--- a/spec/GitHub/PullRequestReviewsSpec.hs
+++ b/spec/GitHub/PullRequestReviewsSpec.hs
@@ -22,10 +22,10 @@ withAuth action = do
 
 spec :: Spec
 spec = do
-    describe "reviewsForR" $ do
+    describe "pullRequestReviewsR" $ do
         it "works" $ withAuth $ \auth -> for_ prs $ \(owner, repo, prid) -> do
             cs <- GitHub.executeRequest auth $
-                GitHub.reviewsForR owner repo prid GitHub.FetchAll 
+                GitHub.pullRequestReviewsR owner repo prid GitHub.FetchAll
             cs `shouldSatisfy` isRight
   where
     prs =

--- a/spec/GitHub/PullRequestReviewsSpec.hs
+++ b/spec/GitHub/PullRequestReviewsSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+module GitHub.PullRequestReviewsSpec where
+
+import qualified GitHub
+import GitHub.Data.Id (Id(Id))
+
+import Prelude ()
+import Prelude.Compat
+
+import Data.Either.Compat   (isRight)
+import Data.Foldable        (for_)
+import Data.String          (fromString)
+import System.Environment   (lookupEnv)
+import Test.Hspec           (Spec, describe, it, pendingWith, shouldSatisfy)
+
+withAuth :: (GitHub.Auth -> IO ()) -> IO ()
+withAuth action = do
+    mtoken <- lookupEnv "GITHUB_TOKEN"
+    case mtoken of
+        Nothing    -> pendingWith "no GITHUB_TOKEN"
+        Just token -> action (GitHub.OAuth $ fromString token)
+
+spec :: Spec
+spec = do
+    describe "reviewsForR" $ do
+        it "works" $ withAuth $ \auth -> for_ prs $ \(owner, repo, prid) -> do
+            cs <- GitHub.executeRequest auth $
+                GitHub.reviewsForR owner repo prid GitHub.FetchAll 
+            cs `shouldSatisfy` isRight
+  where
+    prs =
+      [("phadej", "github", Id 268)]

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -210,6 +210,25 @@ module GitHub (
     pullRequestReviewCommentsR,
     pullRequestReviewCommentR,
 
+    -- ** Pull request reviews
+    -- | See <https://developer.github.com/v3/pulls/reviews/>
+    --
+    -- Missing endpoints:
+    --
+    -- * Delete a pending review
+    -- * Create a pull request review
+    -- * Submit a pull request review
+    -- * Dismiss a pull request review
+    reviewsForR,
+    reviewsFor,
+    reviewsFor',
+    reviewForR,
+    reviewFor,
+    reviewFor',
+    reviewCommentsForR,
+    reviewCommentsFor,
+    reviewCommentsFor',
+
     -- * Repositories
     -- | See <https://developer.github.com/v3/repos/>
     --
@@ -334,6 +353,7 @@ import GitHub.Endpoints.Organizations
 import GitHub.Endpoints.Organizations.Members
 import GitHub.Endpoints.Organizations.Teams
 import GitHub.Endpoints.PullRequests
+import GitHub.Endpoints.PullRequests.Reviews
 import GitHub.Endpoints.PullRequests.ReviewComments
 import GitHub.Endpoints.Repos
 import GitHub.Endpoints.Repos.Collaborators

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -354,7 +354,7 @@ import GitHub.Endpoints.Organizations.Members
 import GitHub.Endpoints.Organizations.Teams
 import GitHub.Endpoints.PullRequests
 import GitHub.Endpoints.PullRequests.Reviews
-import GitHub.Endpoints.PullRequests.ReviewComments
+import GitHub.Endpoints.PullRequests.Comments
 import GitHub.Endpoints.Repos
 import GitHub.Endpoints.Repos.Collaborators
 import GitHub.Endpoints.Repos.Comments

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -207,8 +207,8 @@ module GitHub (
     -- * Create a comment
     -- * Edit a comment
     -- * Delete a comment
-    pullRequestReviewCommentsR,
-    pullRequestReviewCommentR,
+    pullRequestCommentsR,
+    pullRequestCommentR,
 
     -- ** Pull request reviews
     -- | See <https://developer.github.com/v3/pulls/reviews/>
@@ -219,15 +219,15 @@ module GitHub (
     -- * Create a pull request review
     -- * Submit a pull request review
     -- * Dismiss a pull request review
-    reviewsForR,
-    reviewsFor,
-    reviewsFor',
-    reviewForR,
-    reviewFor,
-    reviewFor',
-    reviewCommentsForR,
-    reviewCommentsFor,
-    reviewCommentsFor',
+    pullRequestReviewsR,
+    pullRequestReviews,
+    pullRequestReviews',
+    pullRequestReviewR,
+    pullRequestReview,
+    pullRequestReview',
+    pullRequestReviewCommentsR,
+    pullRequestReviewCommentsIO,
+    pullRequestReviewCommentsIO',
 
     -- * Repositories
     -- | See <https://developer.github.com/v3/repos/>

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -46,6 +46,7 @@ module GitHub.Data (
     module GitHub.Data.Releases,
     module GitHub.Data.Repos,
     module GitHub.Data.Request,
+    module GitHub.Data.Reviews,
     module GitHub.Data.Search,
     module GitHub.Data.Teams,
     module GitHub.Data.URL,
@@ -73,6 +74,7 @@ import GitHub.Data.PullRequests
 import GitHub.Data.Releases
 import GitHub.Data.Repos
 import GitHub.Data.Request
+import GitHub.Data.Reviews
 import GitHub.Data.Search
 import GitHub.Data.Teams
 import GitHub.Data.URL

--- a/src/GitHub/Data/Reviews.hs
+++ b/src/GitHub/Data/Reviews.hs
@@ -55,7 +55,9 @@ instance FromJSON Review where
             o .: "id"
 
 data ReviewComment = ReviewComment
-    { reviewCommentBody :: !Text
+    { reviewCommentId :: !(Id ReviewComment)
+    , reviewCommentUser :: !SimpleUser
+    , reviewCommentBody :: !Text
     , reviewCommentUrl :: !URL
     , reviewCommentPullRequestReviewId :: !(Id Review)
     , reviewCommentDiffHunk :: !Text
@@ -68,8 +70,6 @@ data ReviewComment = ReviewComment
     , reviewCommentUpdatedAt :: !UTCTime
     , reviewCommentHtmlUrl :: !URL
     , reviewCommentPullRequestUrl :: !URL
-    , reviewCommentUser :: !SimpleUser
-    , reviewCommentId :: !(Id ReviewComment)
     } deriving (Show, Generic)
 
 instance NFData ReviewComment where
@@ -79,18 +79,19 @@ instance Binary ReviewComment
 
 instance FromJSON ReviewComment where
     parseJSON =
-        withObject "ReviewComment" $ \o ->
-            ReviewComment <$> o .: "body" <*> o .: "url" <*>
-            o .: "pull_request_review_id" <*>
-            o .: "diff_hunk" <*>
-            o .: "path" <*>
-            o .: "position" <*>
-            o .: "original_position" <*>
-            o .: "commit_id" <*>
-            o .: "original_commit_id" <*>
-            o .: "created_at" <*>
-            o .: "updated_at" <*>
-            o .: "html_url" <*>
-            o .: "pull_request_url" <*>
-            o .: "user" <*>
-            o .: "id"
+        withObject "ReviewComment" $ \o -> ReviewComment
+            <$> o .: "id"
+            <*> o .: "user"
+            <*> o .: "body"
+            <*> o .: "url"
+            <*> o .: "pull_request_review_id"
+            <*> o .: "diff_hunk"
+            <*> o .: "path"
+            <*> o .: "position"
+            <*> o .: "original_position"
+            <*> o .: "commit_id"
+            <*> o .: "original_commit_id"
+            <*> o .: "created_at"
+            <*> o .: "updated_at"
+            <*> o .: "html_url"
+            <*> o .: "pull_request_url"

--- a/src/GitHub/Data/Reviews.hs
+++ b/src/GitHub/Data/Reviews.hs
@@ -1,0 +1,100 @@
+module GitHub.Data.Reviews where
+
+import Data.Text (Text)
+import GitHub.Data.Definitions (SimpleUser)
+import GitHub.Data.Id (Id(Id))
+import GitHub.Data.URL (URL)
+import GitHub.Internal.Prelude
+import Prelude ()
+
+
+data ReviewState
+  = ReviewStatePending
+  | ReviewStateApproved
+  | ReviewStateDismissed
+  | ReviewStateCommented
+  | ReviewStateChangesRequested
+  deriving (Show, Enum, Bounded, Eq, Ord, Generic)
+
+
+instance NFData ReviewState where rnf = genericRnf
+instance Binary ReviewState
+
+
+instance FromJSON ReviewState where
+  parseJSON (String "APPROVED") = pure ReviewStateApproved
+  parseJSON (String "PENDING") = pure ReviewStatePending
+  parseJSON (String "DISMISSED") = pure ReviewStateDismissed
+  parseJSON (String "COMMENTED") = pure ReviewStateCommented
+  parseJSON (String "CHANGES_REQUESTED") = pure ReviewStateChangesRequested
+  parseJSON _ = fail "Unexpected ReviewState"
+
+
+data Review = Review
+  { reviewBody :: !Text
+  , reviewCommitId :: !Text
+  , reviewState :: ReviewState
+  , reviewSubmittedAt :: !UTCTime
+  , reviewPullRequestUrl :: !URL
+  , reviewHtmlUrl :: !Text
+  , reviewUser :: !SimpleUser
+  , reviewId :: !(Id Review)
+  } deriving (Show, Generic)
+
+
+instance NFData Review where rnf = genericRnf
+instance Binary Review
+
+
+instance FromJSON Review where
+  parseJSON = withObject "Review" $ \o -> Review
+    <$> o .: "body"
+    <*> o .: "commit_id"
+    <*> o .: "state"
+    <*> o .: "submitted_at"
+    <*> o .: "pull_request_url"
+    <*> o .: "html_url"
+    <*> o .: "user"
+    <*> o .: "id"
+
+
+data ReviewComment = ReviewComment
+  { reviewCommentBody :: !Text
+  , reviewCommentUrl :: !URL
+  , reviewCommentPullRequestReviewId :: !(Id Review)
+  , reviewCommentDiffHunk :: !Text
+  , reviewCommentPath :: !Text
+  , reviewCommentPosition :: !Int
+  , reviewCommentOriginalPosition :: !Int
+  , reviewCommentCommitId :: !Text
+  , reviewCommentOriginalCommitId :: !Text
+  , reviewCommentCreatedAt :: !UTCTime
+  , reviewCommentUpdatedAt :: !UTCTime
+  , reviewCommentHtmlUrl :: !URL
+  , reviewCommentPullRequestUrl :: !URL
+  , reviewCommentUser :: !SimpleUser
+  , reviewCommentId :: !(Id ReviewComment)
+  } deriving (Show, Generic)
+
+
+instance NFData ReviewComment where rnf = genericRnf
+instance Binary ReviewComment
+
+
+instance FromJSON ReviewComment where
+  parseJSON = withObject "ReviewComment" $ \o -> ReviewComment
+    <$> o .: "body"
+    <*> o .: "url"
+    <*> o .: "pull_request_review_id"
+    <*> o .: "diff_hunk"
+    <*> o .: "path"
+    <*> o .: "position"
+    <*> o .: "original_position"
+    <*> o .: "commit_id"
+    <*> o .: "original_commit_id"
+    <*> o .: "created_at"
+    <*> o .: "updated_at"
+    <*> o .: "html_url"
+    <*> o .: "pull_request_url"
+    <*> o .: "user"
+    <*> o .: "id"

--- a/src/GitHub/Data/Reviews.hs
+++ b/src/GitHub/Data/Reviews.hs
@@ -7,94 +7,90 @@ import GitHub.Data.URL (URL)
 import GitHub.Internal.Prelude
 import Prelude ()
 
-
 data ReviewState
-  = ReviewStatePending
-  | ReviewStateApproved
-  | ReviewStateDismissed
-  | ReviewStateCommented
-  | ReviewStateChangesRequested
-  deriving (Show, Enum, Bounded, Eq, Ord, Generic)
+    = ReviewStatePending
+    | ReviewStateApproved
+    | ReviewStateDismissed
+    | ReviewStateCommented
+    | ReviewStateChangesRequested
+    deriving (Show, Enum, Bounded, Eq, Ord, Generic)
 
+instance NFData ReviewState where
+    rnf = genericRnf
 
-instance NFData ReviewState where rnf = genericRnf
 instance Binary ReviewState
 
-
 instance FromJSON ReviewState where
-  parseJSON (String "APPROVED") = pure ReviewStateApproved
-  parseJSON (String "PENDING") = pure ReviewStatePending
-  parseJSON (String "DISMISSED") = pure ReviewStateDismissed
-  parseJSON (String "COMMENTED") = pure ReviewStateCommented
-  parseJSON (String "CHANGES_REQUESTED") = pure ReviewStateChangesRequested
-  parseJSON _ = fail "Unexpected ReviewState"
-
+    parseJSON (String "APPROVED") = pure ReviewStateApproved
+    parseJSON (String "PENDING") = pure ReviewStatePending
+    parseJSON (String "DISMISSED") = pure ReviewStateDismissed
+    parseJSON (String "COMMENTED") = pure ReviewStateCommented
+    parseJSON (String "CHANGES_REQUESTED") = pure ReviewStateChangesRequested
+    parseJSON _ = fail "Unexpected ReviewState"
 
 data Review = Review
-  { reviewBody :: !Text
-  , reviewCommitId :: !Text
-  , reviewState :: ReviewState
-  , reviewSubmittedAt :: !UTCTime
-  , reviewPullRequestUrl :: !URL
-  , reviewHtmlUrl :: !Text
-  , reviewUser :: !SimpleUser
-  , reviewId :: !(Id Review)
-  } deriving (Show, Generic)
+    { reviewBody :: !Text
+    , reviewCommitId :: !Text
+    , reviewState :: ReviewState
+    , reviewSubmittedAt :: !UTCTime
+    , reviewPullRequestUrl :: !URL
+    , reviewHtmlUrl :: !Text
+    , reviewUser :: !SimpleUser
+    , reviewId :: !(Id Review)
+    } deriving (Show, Generic)
 
+instance NFData Review where
+    rnf = genericRnf
 
-instance NFData Review where rnf = genericRnf
 instance Binary Review
 
-
 instance FromJSON Review where
-  parseJSON = withObject "Review" $ \o -> Review
-    <$> o .: "body"
-    <*> o .: "commit_id"
-    <*> o .: "state"
-    <*> o .: "submitted_at"
-    <*> o .: "pull_request_url"
-    <*> o .: "html_url"
-    <*> o .: "user"
-    <*> o .: "id"
-
+    parseJSON =
+        withObject "Review" $ \o ->
+            Review <$> o .: "body" <*> o .: "commit_id" <*> o .: "state" <*>
+            o .: "submitted_at" <*>
+            o .: "pull_request_url" <*>
+            o .: "html_url" <*>
+            o .: "user" <*>
+            o .: "id"
 
 data ReviewComment = ReviewComment
-  { reviewCommentBody :: !Text
-  , reviewCommentUrl :: !URL
-  , reviewCommentPullRequestReviewId :: !(Id Review)
-  , reviewCommentDiffHunk :: !Text
-  , reviewCommentPath :: !Text
-  , reviewCommentPosition :: !Int
-  , reviewCommentOriginalPosition :: !Int
-  , reviewCommentCommitId :: !Text
-  , reviewCommentOriginalCommitId :: !Text
-  , reviewCommentCreatedAt :: !UTCTime
-  , reviewCommentUpdatedAt :: !UTCTime
-  , reviewCommentHtmlUrl :: !URL
-  , reviewCommentPullRequestUrl :: !URL
-  , reviewCommentUser :: !SimpleUser
-  , reviewCommentId :: !(Id ReviewComment)
-  } deriving (Show, Generic)
+    { reviewCommentBody :: !Text
+    , reviewCommentUrl :: !URL
+    , reviewCommentPullRequestReviewId :: !(Id Review)
+    , reviewCommentDiffHunk :: !Text
+    , reviewCommentPath :: !Text
+    , reviewCommentPosition :: !Int
+    , reviewCommentOriginalPosition :: !Int
+    , reviewCommentCommitId :: !Text
+    , reviewCommentOriginalCommitId :: !Text
+    , reviewCommentCreatedAt :: !UTCTime
+    , reviewCommentUpdatedAt :: !UTCTime
+    , reviewCommentHtmlUrl :: !URL
+    , reviewCommentPullRequestUrl :: !URL
+    , reviewCommentUser :: !SimpleUser
+    , reviewCommentId :: !(Id ReviewComment)
+    } deriving (Show, Generic)
 
+instance NFData ReviewComment where
+    rnf = genericRnf
 
-instance NFData ReviewComment where rnf = genericRnf
 instance Binary ReviewComment
 
-
 instance FromJSON ReviewComment where
-  parseJSON = withObject "ReviewComment" $ \o -> ReviewComment
-    <$> o .: "body"
-    <*> o .: "url"
-    <*> o .: "pull_request_review_id"
-    <*> o .: "diff_hunk"
-    <*> o .: "path"
-    <*> o .: "position"
-    <*> o .: "original_position"
-    <*> o .: "commit_id"
-    <*> o .: "original_commit_id"
-    <*> o .: "created_at"
-    <*> o .: "updated_at"
-    <*> o .: "html_url"
-    <*> o .: "pull_request_url"
-    <*> o .: "user"
-    <*> o .: "id"
+    parseJSON =
+        withObject "ReviewComment" $ \o ->
+            ReviewComment <$> o .: "body" <*> o .: "url" <*>
+            o .: "pull_request_review_id" <*>
+            o .: "diff_hunk" <*>
+            o .: "path" <*>
+            o .: "position" <*>
+            o .: "original_position" <*>
+            o .: "commit_id" <*>
+            o .: "original_commit_id" <*>
+            o .: "created_at" <*>
+            o .: "updated_at" <*>
+            o .: "html_url" <*>
+            o .: "pull_request_url" <*>
+            o .: "user" <*>
+            o .: "id"

--- a/src/GitHub/Data/Reviews.hs
+++ b/src/GitHub/Data/Reviews.hs
@@ -2,7 +2,7 @@ module GitHub.Data.Reviews where
 
 import Data.Text (Text)
 import GitHub.Data.Definitions (SimpleUser)
-import GitHub.Data.Id (Id(Id))
+import GitHub.Data.Id (Id)
 import GitHub.Data.URL (URL)
 import GitHub.Internal.Prelude
 import Prelude ()

--- a/src/GitHub/Endpoints/PullRequests/Comments.hs
+++ b/src/GitHub/Endpoints/PullRequests/Comments.hs
@@ -5,7 +5,7 @@
 --
 -- The pull request review comments API as described at
 -- <http://developer.github.com/v3/pulls/comments/>.
-module GitHub.Endpoints.PullRequests.ReviewComments (
+module GitHub.Endpoints.PullRequests.Comments (
     pullRequestCommentsIO,
     pullRequestCommentsR,
     pullRequestComment,

--- a/src/GitHub/Endpoints/PullRequests/ReviewComments.hs
+++ b/src/GitHub/Endpoints/PullRequests/ReviewComments.hs
@@ -6,10 +6,10 @@
 -- The pull request review comments API as described at
 -- <http://developer.github.com/v3/pulls/comments/>.
 module GitHub.Endpoints.PullRequests.ReviewComments (
-    pullRequestReviewCommentsIO,
-    pullRequestReviewCommentsR,
-    pullRequestReviewComment,
-    pullRequestReviewCommentR,
+    pullRequestCommentsIO,
+    pullRequestCommentsR,
+    pullRequestComment,
+    pullRequestCommentR,
     module GitHub.Data,
     ) where
 
@@ -20,26 +20,26 @@ import Prelude ()
 
 -- | All the comments on a pull request with the given ID.
 --
--- > pullRequestReviewComments "thoughtbot" "factory_girl" (Id 256)
-pullRequestReviewCommentsIO :: Name Owner -> Name Repo -> Id PullRequest -> IO (Either Error (Vector Comment))
-pullRequestReviewCommentsIO user repo prid =
-    executeRequest' $ pullRequestReviewCommentsR user repo prid FetchAll
+-- > pullRequestComments "thoughtbot" "factory_girl" (Id 256)
+pullRequestCommentsIO :: Name Owner -> Name Repo -> Id PullRequest -> IO (Either Error (Vector Comment))
+pullRequestCommentsIO user repo prid =
+    executeRequest' $ pullRequestCommentsR user repo prid FetchAll
 
 -- | List comments on a pull request.
 -- See <https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request>
-pullRequestReviewCommentsR :: Name Owner -> Name Repo -> Id PullRequest -> FetchCount -> Request k (Vector Comment)
-pullRequestReviewCommentsR user repo prid =
+pullRequestCommentsR :: Name Owner -> Name Repo -> Id PullRequest -> FetchCount -> Request k (Vector Comment)
+pullRequestCommentsR user repo prid =
     pagedQuery ["repos", toPathPart user, toPathPart repo, "pulls", toPathPart prid, "comments"] []
 
 -- | One comment on a pull request, by the comment's ID.
 --
--- > pullRequestReviewComment "thoughtbot" "factory_girl" (Id 301819)
-pullRequestReviewComment :: Name Owner -> Name Repo -> Id Comment -> IO (Either Error Comment)
-pullRequestReviewComment user repo cid =
-    executeRequest' $ pullRequestReviewCommentR user repo cid
+-- > pullRequestComment "thoughtbot" "factory_girl" (Id 301819)
+pullRequestComment :: Name Owner -> Name Repo -> Id Comment -> IO (Either Error Comment)
+pullRequestComment user repo cid =
+    executeRequest' $ pullRequestCommentR user repo cid
 
 -- | Query a single comment.
 -- See <https://developer.github.com/v3/pulls/comments/#get-a-single-comment>
-pullRequestReviewCommentR :: Name Owner -> Name Repo -> Id Comment -> Request k Comment
-pullRequestReviewCommentR user repo cid =
+pullRequestCommentR :: Name Owner -> Name Repo -> Id Comment -> Request k Comment
+pullRequestCommentR user repo cid =
     query ["repos", toPathPart user, toPathPart repo, "pulls", "comments", toPathPart cid] []

--- a/src/GitHub/Endpoints/PullRequests/Reviews.hs
+++ b/src/GitHub/Endpoints/PullRequests/Reviews.hs
@@ -1,0 +1,172 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+-- The reviews API as described on <http://developer.github.com/v3/pulls/reviews/>.
+module GitHub.Endpoints.PullRequests.Reviews
+  ( reviewsForR
+  , reviewsFor
+  , reviewsFor'
+  , reviewForR
+  , reviewFor
+  , reviewFor'
+  , reviewCommentsForR
+  , reviewCommentsFor
+  , reviewCommentsFor'
+  , module GitHub.Data
+  ) where
+
+import GitHub.Data
+import GitHub.Data.Id (Id)
+import GitHub.Internal.Prelude
+import GitHub.Request
+       (Request, executeRequest', executeRequestMaybe)
+import Prelude ()
+
+
+-- | List reviews for a pull request.
+-- See <https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request>
+reviewsForR
+  :: Name Owner
+  -> Name Repo
+  -> Id PullRequest
+  -> FetchCount
+  -> Request k (Vector Review)
+reviewsForR owner repo prid =
+  pagedQuery
+    [ "repos"
+    , toPathPart owner
+    , toPathPart repo
+    , "pulls"
+    , toPathPart prid
+    , "reviews"
+    ]
+    []
+
+
+-- | All reviews for a pull request given the repo owner, repo name and the pull
+-- request id.
+--
+-- > reviewsFor "thoughtbot" "paperclip" (Id 101)
+reviewsFor :: Name Owner
+           -> Name Repo
+           -> Id PullRequest
+           -> IO (Either Error (Vector Review))
+reviewsFor owner repo prid =
+  executeRequest' $ reviewsForR owner repo prid FetchAll
+
+
+-- | All reviews for a pull request given the repo owner, repo name and the pull
+-- request id. With authentication.
+--
+-- > reviewsFor' (Just ("github-username", "github-password")) "thoughtbot" "paperclip" (Id 101)
+reviewsFor'
+  :: Maybe Auth
+  -> Name Owner
+  -> Name Repo
+  -> Id PullRequest
+  -> IO (Either Error (Vector Review))
+reviewsFor' auth owner repo pr =
+  executeRequestMaybe auth $ reviewsForR owner repo pr FetchAll
+
+
+-- | Query a single pull request review.
+-- see <https://developer.github.com/v3/pulls/reviews/#get-a-single-review>
+reviewForR :: Name Owner
+           -> Name Repo
+           -> Id PullRequest
+           -> Id Review
+           -> Request k Review
+reviewForR owner repo prid rid =
+  query
+    [ "repos"
+    , toPathPart owner
+    , toPathPart repo
+    , "pulls"
+    , toPathPart prid
+    , "reviews"
+    , toPathPart rid
+    ]
+    []
+
+
+-- | A detailed review on a pull request given the repo owner, repo name, pull
+-- request id and review id.
+--
+-- > reviewFor "thoughtbot" "factory_girl" (Id 301819) (Id 332)
+reviewFor
+  :: Name Owner
+  -> Name Repo
+  -> Id PullRequest
+  -> Id Review
+  -> IO (Either Error Review)
+reviewFor owner repo prid rid =
+  executeRequest' $ reviewForR owner repo prid rid
+
+
+-- | A detailed review on a pull request given the repo owner, repo name, pull
+-- request id and review id. With authentication.
+--
+-- > reviewFor' (Just ("github-username", "github-password"))
+-- "thoughtbot" "factory_girl" (Id 301819) (Id 332)
+reviewFor'
+  :: Maybe Auth
+  -> Name Owner
+  -> Name Repo
+  -> Id PullRequest
+  -> Id Review
+  -> IO (Either Error Review)
+reviewFor' auth owner repo prid rid =
+  executeRequestMaybe auth $ reviewForR owner repo prid rid
+
+
+-- | Query the comments for a single pull request review.
+-- see <https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review>
+reviewCommentsForR
+  :: Name Owner
+  -> Name Repo
+  -> Id PullRequest
+  -> Id Review
+  -> Request k [ReviewComment]
+reviewCommentsForR owner repo prid rid =
+  query
+    [ "repos"
+    , toPathPart owner
+    , toPathPart repo
+    , "pulls"
+    , toPathPart prid
+    , "reviews"
+    , toPathPart rid
+    , "comments"
+    ]
+    []
+
+
+-- | All comments for a review on a pull request given the repo owner, repo
+-- name, pull request id and review id.
+--
+-- > reviewCommentsFor "thoughtbot" "factory_girl" (Id 301819) (Id 332)
+reviewCommentsFor
+  :: Name Owner
+  -> Name Repo
+  -> Id PullRequest
+  -> Id Review
+  -> IO (Either Error [ReviewComment])
+reviewCommentsFor owner repo prid rid =
+  executeRequest' $ reviewCommentsForR owner repo prid rid
+
+
+-- | All comments for a review on a pull request given the repo owner, repo
+-- name, pull request id and review id. With authentication.
+--
+-- > reviewCommentsFor' (Just ("github-username", "github-password")) "thoughtbot" "factory_girl" (Id 301819) (Id 332)
+reviewCommentsFor'
+  :: Maybe Auth
+  -> Name Owner
+  -> Name Repo
+  -> Id PullRequest
+  -> Id Review
+  -> IO (Either Error [ReviewComment])
+reviewCommentsFor' auth owner repo prid rid =
+  executeRequestMaybe auth $ reviewCommentsForR owner repo prid rid

--- a/src/GitHub/Endpoints/PullRequests/Reviews.hs
+++ b/src/GitHub/Endpoints/PullRequests/Reviews.hs
@@ -5,15 +5,15 @@
 --
 -- The reviews API as described on <http://developer.github.com/v3/pulls/reviews/>.
 module GitHub.Endpoints.PullRequests.Reviews
-  ( reviewsForR
-  , reviewsFor
-  , reviewsFor'
-  , reviewForR
-  , reviewFor
-  , reviewFor'
-  , reviewCommentsForR
-  , reviewCommentsFor
-  , reviewCommentsFor'
+  ( pullRequestReviewsR
+  , pullRequestReviews
+  , pullRequestReviews'
+  , pullRequestReviewR
+  , pullRequestReview
+  , pullRequestReview'
+  , pullRequestReviewCommentsR
+  , pullRequestReviewCommentsIO
+  , pullRequestReviewCommentsIO'
   , module GitHub.Data
   ) where
 
@@ -27,13 +27,13 @@ import Prelude ()
 
 -- | List reviews for a pull request.
 -- See <https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request>
-reviewsForR
+pullRequestReviewsR
   :: Name Owner
   -> Name Repo
   -> Id PullRequest
   -> FetchCount
   -> Request k (Vector Review)
-reviewsForR owner repo prid =
+pullRequestReviewsR owner repo prid =
   pagedQuery
     [ "repos"
     , toPathPart owner
@@ -48,37 +48,37 @@ reviewsForR owner repo prid =
 -- | All reviews for a pull request given the repo owner, repo name and the pull
 -- request id.
 --
--- > reviewsFor "thoughtbot" "paperclip" (Id 101)
-reviewsFor :: Name Owner
-           -> Name Repo
-           -> Id PullRequest
-           -> IO (Either Error (Vector Review))
-reviewsFor owner repo prid =
-  executeRequest' $ reviewsForR owner repo prid FetchAll
+-- > pullRequestReviews "thoughtbot" "paperclip" (Id 101)
+pullRequestReviews :: Name Owner
+                   -> Name Repo
+                   -> Id PullRequest
+                   -> IO (Either Error (Vector Review))
+pullRequestReviews owner repo prid =
+  executeRequest' $ pullRequestReviewsR owner repo prid FetchAll
 
 
 -- | All reviews for a pull request given the repo owner, repo name and the pull
 -- request id. With authentication.
 --
--- > reviewsFor' (Just ("github-username", "github-password")) "thoughtbot" "paperclip" (Id 101)
-reviewsFor'
+-- > pullRequestReviews' (Just ("github-username", "github-password")) "thoughtbot" "paperclip" (Id 101)
+pullRequestReviews'
   :: Maybe Auth
   -> Name Owner
   -> Name Repo
   -> Id PullRequest
   -> IO (Either Error (Vector Review))
-reviewsFor' auth owner repo pr =
-  executeRequestMaybe auth $ reviewsForR owner repo pr FetchAll
+pullRequestReviews' auth owner repo pr =
+  executeRequestMaybe auth $ pullRequestReviewsR owner repo pr FetchAll
 
 
 -- | Query a single pull request review.
 -- see <https://developer.github.com/v3/pulls/reviews/#get-a-single-review>
-reviewForR :: Name Owner
-           -> Name Repo
-           -> Id PullRequest
-           -> Id Review
-           -> Request k Review
-reviewForR owner repo prid rid =
+pullRequestReviewR :: Name Owner
+                   -> Name Repo
+                   -> Id PullRequest
+                   -> Id Review
+                   -> Request k Review
+pullRequestReviewR owner repo prid rid =
   query
     [ "repos"
     , toPathPart owner
@@ -94,42 +94,42 @@ reviewForR owner repo prid rid =
 -- | A detailed review on a pull request given the repo owner, repo name, pull
 -- request id and review id.
 --
--- > reviewFor "thoughtbot" "factory_girl" (Id 301819) (Id 332)
-reviewFor
+-- > pullRequestReview "thoughtbot" "factory_girl" (Id 301819) (Id 332)
+pullRequestReview
   :: Name Owner
   -> Name Repo
   -> Id PullRequest
   -> Id Review
   -> IO (Either Error Review)
-reviewFor owner repo prid rid =
-  executeRequest' $ reviewForR owner repo prid rid
+pullRequestReview owner repo prid rid =
+  executeRequest' $ pullRequestReviewR owner repo prid rid
 
 
 -- | A detailed review on a pull request given the repo owner, repo name, pull
 -- request id and review id. With authentication.
 --
--- > reviewFor' (Just ("github-username", "github-password"))
+-- > pullRequestReview' (Just ("github-username", "github-password"))
 -- "thoughtbot" "factory_girl" (Id 301819) (Id 332)
-reviewFor'
+pullRequestReview'
   :: Maybe Auth
   -> Name Owner
   -> Name Repo
   -> Id PullRequest
   -> Id Review
   -> IO (Either Error Review)
-reviewFor' auth owner repo prid rid =
-  executeRequestMaybe auth $ reviewForR owner repo prid rid
+pullRequestReview' auth owner repo prid rid =
+  executeRequestMaybe auth $ pullRequestReviewR owner repo prid rid
 
 
 -- | Query the comments for a single pull request review.
 -- see <https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review>
-reviewCommentsForR
+pullRequestReviewCommentsR
   :: Name Owner
   -> Name Repo
   -> Id PullRequest
   -> Id Review
   -> Request k [ReviewComment]
-reviewCommentsForR owner repo prid rid =
+pullRequestReviewCommentsR owner repo prid rid =
   query
     [ "repos"
     , toPathPart owner
@@ -146,27 +146,27 @@ reviewCommentsForR owner repo prid rid =
 -- | All comments for a review on a pull request given the repo owner, repo
 -- name, pull request id and review id.
 --
--- > reviewCommentsFor "thoughtbot" "factory_girl" (Id 301819) (Id 332)
-reviewCommentsFor
+-- > pullRequestReviewComments "thoughtbot" "factory_girl" (Id 301819) (Id 332)
+pullRequestReviewCommentsIO
   :: Name Owner
   -> Name Repo
   -> Id PullRequest
   -> Id Review
   -> IO (Either Error [ReviewComment])
-reviewCommentsFor owner repo prid rid =
-  executeRequest' $ reviewCommentsForR owner repo prid rid
+pullRequestReviewCommentsIO owner repo prid rid =
+  executeRequest' $ pullRequestReviewCommentsR owner repo prid rid
 
 
 -- | All comments for a review on a pull request given the repo owner, repo
 -- name, pull request id and review id. With authentication.
 --
--- > reviewCommentsFor' (Just ("github-username", "github-password")) "thoughtbot" "factory_girl" (Id 301819) (Id 332)
-reviewCommentsFor'
+-- > pullRequestReviewComments' (Just ("github-username", "github-password")) "thoughtbot" "factory_girl" (Id 301819) (Id 332)
+pullRequestReviewCommentsIO'
   :: Maybe Auth
   -> Name Owner
   -> Name Repo
   -> Id PullRequest
   -> Id Review
   -> IO (Either Error [ReviewComment])
-reviewCommentsFor' auth owner repo prid rid =
-  executeRequestMaybe auth $ reviewCommentsForR owner repo prid rid
+pullRequestReviewCommentsIO' auth owner repo prid rid =
+  executeRequestMaybe auth $ pullRequestReviewCommentsR owner repo prid rid

--- a/src/GitHub/Endpoints/PullRequests/Reviews.hs
+++ b/src/GitHub/Endpoints/PullRequests/Reviews.hs
@@ -5,17 +5,17 @@
 --
 -- The reviews API as described on <http://developer.github.com/v3/pulls/reviews/>.
 module GitHub.Endpoints.PullRequests.Reviews
-  ( pullRequestReviewsR
-  , pullRequestReviews
-  , pullRequestReviews'
-  , pullRequestReviewR
-  , pullRequestReview
-  , pullRequestReview'
-  , pullRequestReviewCommentsR
-  , pullRequestReviewCommentsIO
-  , pullRequestReviewCommentsIO'
-  , module GitHub.Data
-  ) where
+    ( pullRequestReviewsR
+    , pullRequestReviews
+    , pullRequestReviews'
+    , pullRequestReviewR
+    , pullRequestReview
+    , pullRequestReview'
+    , pullRequestReviewCommentsR
+    , pullRequestReviewCommentsIO
+    , pullRequestReviewCommentsIO'
+    , module GitHub.Data
+    ) where
 
 import GitHub.Data
 import GitHub.Data.Id (Id)
@@ -24,86 +24,82 @@ import GitHub.Request
        (Request, executeRequest', executeRequestMaybe)
 import Prelude ()
 
-
 -- | List reviews for a pull request.
 -- See <https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request>
 pullRequestReviewsR
-  :: Name Owner
-  -> Name Repo
-  -> Id PullRequest
-  -> FetchCount
-  -> Request k (Vector Review)
+    :: Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> FetchCount
+    -> Request k (Vector Review)
 pullRequestReviewsR owner repo prid =
-  pagedQuery
-    [ "repos"
-    , toPathPart owner
-    , toPathPart repo
-    , "pulls"
-    , toPathPart prid
-    , "reviews"
-    ]
-    []
-
+    pagedQuery
+        [ "repos"
+        , toPathPart owner
+        , toPathPart repo
+        , "pulls"
+        , toPathPart prid
+        , "reviews"
+        ]
+        []
 
 -- | All reviews for a pull request given the repo owner, repo name and the pull
 -- request id.
 --
 -- > pullRequestReviews "thoughtbot" "paperclip" (Id 101)
-pullRequestReviews :: Name Owner
-                   -> Name Repo
-                   -> Id PullRequest
-                   -> IO (Either Error (Vector Review))
+pullRequestReviews
+    :: Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> IO (Either Error (Vector Review))
 pullRequestReviews owner repo prid =
-  executeRequest' $ pullRequestReviewsR owner repo prid FetchAll
-
+    executeRequest' $ pullRequestReviewsR owner repo prid FetchAll
 
 -- | All reviews for a pull request given the repo owner, repo name and the pull
 -- request id. With authentication.
 --
 -- > pullRequestReviews' (Just ("github-username", "github-password")) "thoughtbot" "paperclip" (Id 101)
 pullRequestReviews'
-  :: Maybe Auth
-  -> Name Owner
-  -> Name Repo
-  -> Id PullRequest
-  -> IO (Either Error (Vector Review))
+    :: Maybe Auth
+    -> Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> IO (Either Error (Vector Review))
 pullRequestReviews' auth owner repo pr =
-  executeRequestMaybe auth $ pullRequestReviewsR owner repo pr FetchAll
-
+    executeRequestMaybe auth $ pullRequestReviewsR owner repo pr FetchAll
 
 -- | Query a single pull request review.
 -- see <https://developer.github.com/v3/pulls/reviews/#get-a-single-review>
-pullRequestReviewR :: Name Owner
-                   -> Name Repo
-                   -> Id PullRequest
-                   -> Id Review
-                   -> Request k Review
+pullRequestReviewR
+    :: Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> Id Review
+    -> Request k Review
 pullRequestReviewR owner repo prid rid =
-  query
-    [ "repos"
-    , toPathPart owner
-    , toPathPart repo
-    , "pulls"
-    , toPathPart prid
-    , "reviews"
-    , toPathPart rid
-    ]
-    []
-
+    query
+        [ "repos"
+        , toPathPart owner
+        , toPathPart repo
+        , "pulls"
+        , toPathPart prid
+        , "reviews"
+        , toPathPart rid
+        ]
+        []
 
 -- | A detailed review on a pull request given the repo owner, repo name, pull
 -- request id and review id.
 --
 -- > pullRequestReview "thoughtbot" "factory_girl" (Id 301819) (Id 332)
 pullRequestReview
-  :: Name Owner
-  -> Name Repo
-  -> Id PullRequest
-  -> Id Review
-  -> IO (Either Error Review)
+    :: Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> Id Review
+    -> IO (Either Error Review)
 pullRequestReview owner repo prid rid =
-  executeRequest' $ pullRequestReviewR owner repo prid rid
-
+    executeRequest' $ pullRequestReviewR owner repo prid rid
 
 -- | A detailed review on a pull request given the repo owner, repo name, pull
 -- request id and review id. With authentication.
@@ -111,62 +107,59 @@ pullRequestReview owner repo prid rid =
 -- > pullRequestReview' (Just ("github-username", "github-password"))
 -- "thoughtbot" "factory_girl" (Id 301819) (Id 332)
 pullRequestReview'
-  :: Maybe Auth
-  -> Name Owner
-  -> Name Repo
-  -> Id PullRequest
-  -> Id Review
-  -> IO (Either Error Review)
+    :: Maybe Auth
+    -> Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> Id Review
+    -> IO (Either Error Review)
 pullRequestReview' auth owner repo prid rid =
-  executeRequestMaybe auth $ pullRequestReviewR owner repo prid rid
-
+    executeRequestMaybe auth $ pullRequestReviewR owner repo prid rid
 
 -- | Query the comments for a single pull request review.
 -- see <https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review>
 pullRequestReviewCommentsR
-  :: Name Owner
-  -> Name Repo
-  -> Id PullRequest
-  -> Id Review
-  -> Request k [ReviewComment]
+    :: Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> Id Review
+    -> Request k [ReviewComment]
 pullRequestReviewCommentsR owner repo prid rid =
-  query
-    [ "repos"
-    , toPathPart owner
-    , toPathPart repo
-    , "pulls"
-    , toPathPart prid
-    , "reviews"
-    , toPathPart rid
-    , "comments"
-    ]
-    []
-
+    query
+        [ "repos"
+        , toPathPart owner
+        , toPathPart repo
+        , "pulls"
+        , toPathPart prid
+        , "reviews"
+        , toPathPart rid
+        , "comments"
+        ]
+        []
 
 -- | All comments for a review on a pull request given the repo owner, repo
 -- name, pull request id and review id.
 --
 -- > pullRequestReviewComments "thoughtbot" "factory_girl" (Id 301819) (Id 332)
 pullRequestReviewCommentsIO
-  :: Name Owner
-  -> Name Repo
-  -> Id PullRequest
-  -> Id Review
-  -> IO (Either Error [ReviewComment])
+    :: Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> Id Review
+    -> IO (Either Error [ReviewComment])
 pullRequestReviewCommentsIO owner repo prid rid =
-  executeRequest' $ pullRequestReviewCommentsR owner repo prid rid
-
+    executeRequest' $ pullRequestReviewCommentsR owner repo prid rid
 
 -- | All comments for a review on a pull request given the repo owner, repo
 -- name, pull request id and review id. With authentication.
 --
 -- > pullRequestReviewComments' (Just ("github-username", "github-password")) "thoughtbot" "factory_girl" (Id 301819) (Id 332)
 pullRequestReviewCommentsIO'
-  :: Maybe Auth
-  -> Name Owner
-  -> Name Repo
-  -> Id PullRequest
-  -> Id Review
-  -> IO (Either Error [ReviewComment])
+    :: Maybe Auth
+    -> Name Owner
+    -> Name Repo
+    -> Id PullRequest
+    -> Id Review
+    -> IO (Either Error [ReviewComment])
 pullRequestReviewCommentsIO' auth owner repo prid rid =
-  executeRequestMaybe auth $ pullRequestReviewCommentsR owner repo prid rid
+    executeRequestMaybe auth $ pullRequestReviewCommentsR owner repo prid rid


### PR DESCRIPTION
I think this is 99% ready but one important part I think this needs some direction on is naming. There's already support in this lib for the very similarly named but slightly different review comments and so I'm not sure if I've picked the best possible naming conventions

https://developer.github.com/v3/pulls/reviews/
https://developer.github.com/v3/pulls/comments/

I based the function names on the [pull request function names](https://hackage.haskell.org/package/github-0.15.0/docs/GitHub-Endpoints-PullRequests.html) purely for brevity but perhaps I should have used the longer form for consistency with the existing review comments.

I also added a `ReviewComment` data type before realising there's already a concept of a "review comment". Not sure if that's an issue