### PR TITLE
Add Repo Contents API endpoints.

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -112,6 +112,7 @@ Library
     GitHub.Endpoints.Repos.Collaborators
     GitHub.Endpoints.Repos.Comments
     GitHub.Endpoints.Repos.Commits
+    GitHub.Endpoints.Repos.Contents
     GitHub.Endpoints.Repos.DeployKeys
     GitHub.Endpoints.Repos.Forks
     GitHub.Endpoints.Repos.Releases

--- a/samples/Repos/Contents.hs
+++ b/samples/Repos/Contents.hs
@@ -5,8 +5,10 @@ module Main where
 
 import           Common                          hiding
                  (getContents, intercalate, take, truncate, unlines)
+import qualified Data.ByteString.Base64          as Base64
 import           Data.Text
-                 (Text, intercalate, pack, take, unlines)
+                 (Text, intercalate, take, unlines)
+import           Data.Text.Encoding              (decodeUtf8, encodeUtf8)
 import           Data.Text.IO                    (putStrLn)
 import qualified Data.Vector                     as Vector
 import qualified GitHub.Data                     as GitHub
@@ -21,6 +23,8 @@ main = do
   putStrLn "LICENSE"
   putStrLn "======="
   getContents "LICENSE"
+
+  createUpdateDeleteSampleFile
 
 getContents :: Text -> IO ()
 getContents path = do
@@ -50,9 +54,63 @@ formatContentInfo contentInfo =
     , "html url: " <> (GitHub.getUrl . GitHub.contentHtmlUrl) contentInfo
     ]
 
+formatItem :: GitHub.ContentItem -> Text
 formatItem item =
    "type: " <> tshow (GitHub.contentItemType item) <> "\n" <>
   formatContentInfo (GitHub.contentItemInfo item)
 
-
+truncate :: Text -> Text
 truncate str = take 40 str <> "... (truncated)"
+
+createUpdateDeleteSampleFile :: IO ()
+createUpdateDeleteSampleFile = do
+  let
+    auth = GitHub.OAuth "oauthtoken"
+    owner = "repoOwner"
+    repo = "repoName"
+    author = GitHub.Author
+      { GitHub.authorName = "John Doe"
+      , GitHub.authorEmail = "johndoe@example.com"
+      }
+    defaultBranch = Nothing
+    base64Encode = decodeUtf8 . Base64.encode . encodeUtf8
+  createResult <- failOnError $ GitHub.createFile auth owner repo
+    GitHub.CreateFile
+    { GitHub.createFilePath      = "sample.txt"
+    , GitHub.createFileMessage   = "Add sample.txt"
+    , GitHub.createFileContent   = base64Encode "Hello"
+    , GitHub.createFileBranch    = defaultBranch
+    , GitHub.createFileAuthor    = Just author
+    , GitHub.createFileCommitter = Just author
+    }
+
+  let getResultSHA = GitHub.contentSha . GitHub.contentResultInfo . GitHub.contentResultContent
+  let createFileSHA = getResultSHA createResult
+  updateResult <- failOnError $ GitHub.updateFile auth owner repo
+    GitHub.UpdateFile
+    { GitHub.updateFilePath      = "sample.txt"
+    , GitHub.updateFileMessage   = "Update sample.txt"
+    , GitHub.updateFileContent   = base64Encode "Hello world!"
+    , GitHub.updateFileSHA       = createFileSHA
+    , GitHub.updateFileBranch    = defaultBranch
+    , GitHub.updateFileAuthor    = Just author
+    , GitHub.updateFileCommitter = Just author
+    }
+
+  let updateFileSHA = getResultSHA updateResult
+  failOnError $ GitHub.deleteFile auth owner repo
+    GitHub.DeleteFile
+    { GitHub.deleteFilePath      = "sample.txt"
+    , GitHub.deleteFileMessage   = "Delete sample.txt"
+    , GitHub.deleteFileSHA       = updateFileSHA
+    , GitHub.deleteFileBranch    = defaultBranch
+    , GitHub.deleteFileAuthor    = Just author
+    , GitHub.deleteFileCommitter = Just author
+    }
+
+failOnError :: IO (Either GitHub.Error a) -> IO a
+failOnError c = c >>= go
+  where
+  go r = case r of
+    Left err -> fail . show $ err
+    Right x -> return x

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -190,6 +190,20 @@ executable github-operational
     , transformers-compat
   default-language: Haskell2010
 
+executable github-repos-contents-example
+  main-is: Contents.hs
+  hs-source-dirs:
+      Repos
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , github-samples
+    , text
+    , vector
+  default-language: Haskell2010
+
 executable github-show-deploy-key
   main-is: ShowDeployKey.hs
   hs-source-dirs:

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -198,6 +198,7 @@ executable github-repos-contents-example
   build-depends:
       base
     , base-compat
+    , base64-bytestring
     , github
     , github-samples
     , text

--- a/src/GitHub/Data/Content.hs
+++ b/src/GitHub/Data/Content.hs
@@ -5,6 +5,7 @@
 --
 module GitHub.Data.Content where
 
+import GitHub.Data.GitData
 import GitHub.Data.URL
 import GitHub.Internal.Prelude
 import Prelude ()
@@ -54,6 +55,15 @@ data ContentInfo = ContentInfo {
 
 instance NFData ContentInfo where rnf = genericRnf
 instance Binary ContentInfo
+
+data ContentResult = ContentResult
+    { contentResultInfo   :: !ContentInfo
+    , contentResultSize   :: !Int
+    , contentResultCommit :: !Commit
+    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData ContentResult where rnf = genericRnf
+instance Binary ContentResult
 
 data Author = Author
     { authorName  :: !Text
@@ -136,6 +146,12 @@ instance FromJSON ContentInfo where
                 <*> o .: "url"
                 <*> o .: "git_url"
                 <*> o .: "html_url"
+
+instance FromJSON ContentResult where
+  parseJSON = withObject "ContentResult" $ \o ->
+    ContentResult <$> parseJSON (Object o)
+                  <*> o .: "size"
+                  <*> o .: "commit"
 
 instance ToJSON Author where
   toJSON (Author { authorName   = name

--- a/src/GitHub/Data/Content.hs
+++ b/src/GitHub/Data/Content.hs
@@ -56,10 +56,17 @@ data ContentInfo = ContentInfo {
 instance NFData ContentInfo where rnf = genericRnf
 instance Binary ContentInfo
 
+data ContentResultInfo = ContentResultInfo
+    { contentResultInfo :: !ContentInfo
+    , contentResultSize :: !Int
+    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData ContentResultInfo where rnf = genericRnf
+instance Binary ContentResultInfo
+
 data ContentResult = ContentResult
-    { contentResultInfo   :: !ContentInfo
-    , contentResultSize   :: !Int
-    , contentResultCommit :: !Commit
+    { contentResultContent  :: !ContentResultInfo
+    , contentResultCommit   :: !GitCommit
     } deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
 instance NFData ContentResult where rnf = genericRnf
@@ -147,10 +154,14 @@ instance FromJSON ContentInfo where
                 <*> o .: "git_url"
                 <*> o .: "html_url"
 
+instance FromJSON ContentResultInfo where
+  parseJSON = withObject "ContentResultInfo" $ \o ->
+    ContentResultInfo <$> parseJSON (Object o)
+                  <*> o .: "size"
+
 instance FromJSON ContentResult where
   parseJSON = withObject "ContentResult" $ \o ->
-    ContentResult <$> parseJSON (Object o)
-                  <*> o .: "size"
+    ContentResult <$> o .: "content"
                   <*> o .: "commit"
 
 instance ToJSON Author where

--- a/src/GitHub/Data/Content.hs
+++ b/src/GitHub/Data/Content.hs
@@ -55,6 +55,55 @@ data ContentInfo = ContentInfo {
 instance NFData ContentInfo where rnf = genericRnf
 instance Binary ContentInfo
 
+data Author = Author
+    { authorName  :: !Text
+    , authorEmail :: !Text
+    }
+    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+instance NFData Author where rnf = genericRnf
+instance Binary Author
+
+data CreateFile = CreateFile
+    { createFilePath      :: !Text
+    , createFileMessage   :: !Text
+    , createFileContent   :: !Text
+    , createFileBranch    :: !(Maybe Text)
+    , createFileAuthor    :: !(Maybe Author)
+    , createFileCommitter :: !(Maybe Author)
+    }
+    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+instance NFData CreateFile where rnf = genericRnf
+instance Binary CreateFile
+
+data UpdateFile = UpdateFile
+    { updateFilePath      :: !Text
+    , updateFileMessage   :: !Text
+    , updateFileContent   :: !Text
+    , updateFileSHA       :: !Text
+    , updateFileBranch    :: !(Maybe Text)
+    , updateFileAuthor    :: !(Maybe Author)
+    , updateFileCommitter :: !(Maybe Author)
+    }
+    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+instance NFData UpdateFile where rnf = genericRnf
+instance Binary UpdateFile
+
+data DeleteFile = DeleteFile
+    { deleteFilePath      :: !Text
+    , deleteFileMessage   :: !Text
+    , deleteFileSHA       :: !Text
+    , deleteFileBranch    :: !(Maybe Text)
+    , deleteFileAuthor    :: !(Maybe Author)
+    , deleteFileCommitter :: !(Maybe Author)
+    }
+    deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+instance NFData DeleteFile where rnf = genericRnf
+instance Binary DeleteFile
+
 instance FromJSON Content where
   parseJSON o@(Object _) = ContentFile <$> parseJSON o
   parseJSON (Array os) = ContentDirectory <$> traverse parseJSON os
@@ -87,3 +136,61 @@ instance FromJSON ContentInfo where
                 <*> o .: "url"
                 <*> o .: "git_url"
                 <*> o .: "html_url"
+
+instance ToJSON Author where
+  toJSON (Author { authorName   = name
+                 , authorEmail  = email
+                 }) = object
+                 [ "name"      .= name
+                 , "email"     .= email
+                 ]
+
+instance ToJSON CreateFile where
+  toJSON (CreateFile { createFilePath       = path
+                     , createFileMessage    = message
+                     , createFileContent    = content
+                     , createFileBranch     = branch
+                     , createFileAuthor     = author
+                     , createFileCommitter  = committer
+                     }) = object
+                     [ "path"              .= path
+                     , "message"           .= message
+                     , "content"           .= content
+                     , "branch"            .= branch
+                     , "author"            .= author
+                     , "committer"         .= committer
+                     ]
+
+instance ToJSON UpdateFile where
+  toJSON (UpdateFile { updateFilePath       = path
+                     , updateFileMessage    = message
+                     , updateFileContent    = content
+                     , updateFileSHA        = sha
+                     , updateFileBranch     = branch
+                     , updateFileAuthor     = author
+                     , updateFileCommitter  = committer
+                     }) = object
+                     [ "path"              .= path
+                     , "message"           .= message
+                     , "content"           .= content
+                     , "sha"               .= sha
+                     , "branch"            .= branch
+                     , "author"            .= author
+                     , "committer"         .= committer
+                     ]
+
+instance ToJSON DeleteFile where
+  toJSON (DeleteFile { deleteFilePath       = path
+                     , deleteFileMessage    = message
+                     , deleteFileSHA        = sha
+                     , deleteFileBranch     = branch
+                     , deleteFileAuthor     = author
+                     , deleteFileCommitter  = committer
+                     }) = object
+                     [ "path"              .= path
+                     , "message"           .= message
+                     , "sha"               .= sha
+                     , "branch"            .= branch
+                     , "author"            .= author
+                     , "committer"         .= committer
+                     ]

--- a/src/GitHub/Data/Content.hs
+++ b/src/GitHub/Data/Content.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 -----------------------------------------------------------------------------
 -- |
 -- License     :  BSD-3-Clause
@@ -5,7 +6,7 @@
 --
 module GitHub.Data.Content where
 
-import Data.Aeson.Types        (KeyValue)
+import Data.Aeson.Types        (Pair)
 import Data.Maybe              (maybe)
 import GitHub.Data.GitData
 import GitHub.Data.URL
@@ -167,62 +168,41 @@ instance FromJSON ContentResult where
                   <*> o .: "commit"
 
 instance ToJSON Author where
-  toJSON (Author { authorName   = name
-                 , authorEmail  = email
-                 }) = object
-                 [ "name"      .= name
-                 , "email"     .= email
-                 ]
+  toJSON Author {..} = object
+    [ "name"  .= authorName
+    , "email" .= authorEmail
+    ]
 
 instance ToJSON CreateFile where
-  toJSON (CreateFile { createFilePath       = path
-                     , createFileMessage    = message
-                     , createFileContent    = content
-                     , createFileBranch     = branch
-                     , createFileAuthor     = author
-                     , createFileCommitter  = committer
-                     }) = object $
-                     [ "path"              .= path
-                     , "message"           .= message
-                     , "content"           .= content
-                     ]
-                     ++ "branch"           .=? branch
-                     ++ "author"           .=? author
-                     ++ "committer"        .=? committer
+  toJSON CreateFile {..} = object $
+    [ "path"       .= createFilePath
+    , "message"    .= createFileMessage
+    , "content"    .= createFileContent
+    ]
+    ++ "branch"    .=? createFileBranch
+    ++ "author"    .=? createFileAuthor
+    ++ "committer" .=? createFileCommitter
 
 instance ToJSON UpdateFile where
-  toJSON (UpdateFile { updateFilePath       = path
-                     , updateFileMessage    = message
-                     , updateFileContent    = content
-                     , updateFileSHA        = sha
-                     , updateFileBranch     = branch
-                     , updateFileAuthor     = author
-                     , updateFileCommitter  = committer
-                     }) = object $
-                     [ "path"              .= path
-                     , "message"           .= message
-                     , "content"           .= content
-                     , "sha"               .= sha
-                     ]
-                     ++ "branch"           .=? branch
-                     ++ "author"           .=? author
-                     ++ "committer"        .=? committer
+  toJSON UpdateFile {..} = object $
+    [ "path"       .= updateFilePath
+    , "message"    .= updateFileMessage
+    , "content"    .= updateFileContent
+    , "sha"        .= updateFileSHA
+    ]
+    ++ "branch"    .=? updateFileBranch
+    ++ "author"    .=? updateFileAuthor
+    ++ "committer" .=? updateFileCommitter
 
 instance ToJSON DeleteFile where
-  toJSON (DeleteFile { deleteFilePath       = path
-                     , deleteFileMessage    = message
-                     , deleteFileSHA        = sha
-                     , deleteFileBranch     = branch
-                     , deleteFileAuthor     = author
-                     , deleteFileCommitter  = committer
-                     }) = object $
-                     [ "path"              .= path
-                     , "message"           .= message
-                     , "sha"               .= sha
-                     ]
-                     ++ "branch"           .=? branch
-                     ++ "author"           .=? author
-                     ++ "committer"        .=? committer
+  toJSON DeleteFile {..} = object $
+    [ "path"       .= deleteFilePath
+    , "message"    .= deleteFileMessage
+    , "sha"        .= deleteFileSHA
+    ]
+    ++ "branch"    .=? deleteFileBranch
+    ++ "author"    .=? deleteFileAuthor
+    ++ "committer" .=? deleteFileCommitter
 
-(.=?) :: ToJSON v => KeyValue t => Text -> Maybe v -> [t]
+(.=?) :: ToJSON v => Text -> Maybe v -> [Pair]
 name .=? value = maybe [] (pure . (name .=)) value

--- a/src/GitHub/Data/Content.hs
+++ b/src/GitHub/Data/Content.hs
@@ -5,6 +5,8 @@
 --
 module GitHub.Data.Content where
 
+import Data.Aeson.Types        (KeyValue)
+import Data.Maybe              (maybe)
 import GitHub.Data.GitData
 import GitHub.Data.URL
 import GitHub.Internal.Prelude
@@ -179,14 +181,14 @@ instance ToJSON CreateFile where
                      , createFileBranch     = branch
                      , createFileAuthor     = author
                      , createFileCommitter  = committer
-                     }) = object
+                     }) = object $
                      [ "path"              .= path
                      , "message"           .= message
                      , "content"           .= content
-                     , "branch"            .= branch
-                     , "author"            .= author
-                     , "committer"         .= committer
                      ]
+                     ++ "branch"           .=? branch
+                     ++ "author"           .=? author
+                     ++ "committer"        .=? committer
 
 instance ToJSON UpdateFile where
   toJSON (UpdateFile { updateFilePath       = path
@@ -196,15 +198,15 @@ instance ToJSON UpdateFile where
                      , updateFileBranch     = branch
                      , updateFileAuthor     = author
                      , updateFileCommitter  = committer
-                     }) = object
+                     }) = object $
                      [ "path"              .= path
                      , "message"           .= message
                      , "content"           .= content
                      , "sha"               .= sha
-                     , "branch"            .= branch
-                     , "author"            .= author
-                     , "committer"         .= committer
                      ]
+                     ++ "branch"           .=? branch
+                     ++ "author"           .=? author
+                     ++ "committer"        .=? committer
 
 instance ToJSON DeleteFile where
   toJSON (DeleteFile { deleteFilePath       = path
@@ -213,11 +215,14 @@ instance ToJSON DeleteFile where
                      , deleteFileBranch     = branch
                      , deleteFileAuthor     = author
                      , deleteFileCommitter  = committer
-                     }) = object
+                     }) = object $
                      [ "path"              .= path
                      , "message"           .= message
                      , "sha"               .= sha
-                     , "branch"            .= branch
-                     , "author"            .= author
-                     , "committer"         .= committer
                      ]
+                     ++ "branch"           .=? branch
+                     ++ "author"           .=? author
+                     ++ "committer"        .=? committer
+
+(.=?) :: ToJSON v => KeyValue t => Text -> Maybe v -> [t]
+name .=? value = maybe [] (pure . (name .=)) value

--- a/src/GitHub/Endpoints/Repos.hs
+++ b/src/GitHub/Endpoints/Repos.hs
@@ -32,10 +32,6 @@ module GitHub.Endpoints.Repos (
     branchesFor,
     branchesFor',
     branchesForR,
-    contentsFor,
-    contentsFor',
-    readmeFor,
-    readmeFor',
 
     -- ** Create
     createRepo',
@@ -60,8 +56,6 @@ import GitHub.Data
 import GitHub.Internal.Prelude
 import GitHub.Request
 import Prelude ()
-
-import qualified Data.Text.Encoding as TE
 
 repoPublicityQueryString :: RepoPublicity -> QueryString
 repoPublicityQueryString RepoPublicityAll     = [("type", Just "all")]
@@ -322,49 +316,6 @@ branchesFor' auth user repo =
 branchesForR :: Name Owner -> Name Repo -> FetchCount -> Request k (Vector Branch)
 branchesForR user repo =
     pagedQuery  ["repos", toPathPart user, toPathPart repo, "branches"] []
-
--- | The contents of a file or directory in a repo, given the repo owner, name, and path to the file
---
--- > contentsFor "thoughtbot" "paperclip" "README.md"
-contentsFor :: Name Owner -> Name Repo -> Text -> Maybe Text -> IO (Either Error Content)
-contentsFor = contentsFor' Nothing
-
--- | The contents of a file or directory in a repo, given the repo owner, name, and path to the file
--- With Authentication
---
--- > contentsFor' (Just (BasicAuth (user, password))) "thoughtbot" "paperclip" "README.md" Nothing
-contentsFor' :: Maybe Auth ->  Name Owner -> Name Repo -> Text -> Maybe Text -> IO (Either Error Content)
-contentsFor' auth user repo path ref =
-    executeRequestMaybe auth $ contentsForR user repo path ref
-
-contentsForR
-    :: Name Owner
-    -> Name Repo
-    -> Text            -- ^ file or directory
-    -> Maybe Text      -- ^ Git commit
-    -> Request k Content
-contentsForR user repo path ref =
-    query ["repos", toPathPart user, toPathPart repo, "contents", path] qs
-  where
-    qs =  maybe [] (\r -> [("ref", Just . TE.encodeUtf8 $ r)]) ref
-
--- | The contents of a README file in a repo, given the repo owner and name
---
--- > readmeFor "thoughtbot" "paperclip"
-readmeFor :: Name Owner -> Name Repo -> IO (Either Error Content)
-readmeFor = readmeFor' Nothing
-
--- | The contents of a README file in a repo, given the repo owner and name
--- With Authentication
---
--- > readmeFor' (Just (BasicAuth (user, password))) "thoughtbot" "paperclip"
-readmeFor' :: Maybe Auth -> Name Owner -> Name Repo -> IO (Either Error Content)
-readmeFor' auth user repo =
-    executeRequestMaybe auth $ readmeForR user repo
-
-readmeForR :: Name Owner -> Name Repo -> Request k Content
-readmeForR user repo =
-    query ["repos", toPathPart user, toPathPart repo, "readme"] []
 
 -- | Delete an existing repository.
 --

--- a/src/GitHub/Endpoints/Repos/Contents.hs
+++ b/src/GitHub/Endpoints/Repos/Contents.hs
@@ -1,11 +1,30 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+-- The Github Repo Contents API, as documented at
+-- <https://developer.github.com/v3/repos/contents/>
 module GitHub.Endpoints.Repos.Contents (
-    -- * Querying repositories
+    -- * Querying contents
     contentsFor,
     contentsFor',
     contentsForR,
     readmeFor,
     readmeFor',
-    readmeForR
+    readmeForR,
+
+    -- ** Create
+    createFile,
+    createFileR,
+
+    -- ** Update
+    updateFile,
+    updateFileR,
+
+    -- ** Delete
+    deleteFile,
+    deleteFileR
     ) where
 
 import GitHub.Data
@@ -57,3 +76,63 @@ readmeFor' auth user repo =
 readmeForR :: Name Owner -> Name Repo -> Request k Content
 readmeForR user repo =
     query ["repos", toPathPart user, toPathPart repo, "readme"] []
+
+-- | Create a file.
+createFile
+    :: Auth
+    -> Name Owner      -- ^ owner
+    -> Name Repo       -- ^ repository name
+    -> CreateFile
+    -> IO (Either Error Content)
+createFile auth user repo body =
+    executeRequest auth $ createFileR user repo body
+
+-- | Create a file.
+-- See <https://developer.github.com/v3/repos/contents/#create-a-file>
+createFileR
+    :: Name Owner
+    -> Name Repo
+    -> CreateFile
+    -> Request 'RW Content
+createFileR user repo body =
+    command Put ["repos", toPathPart user, toPathPart repo, "contents", createFilePath body] (encode body)
+
+-- | Update a file.
+updateFile
+    :: Auth
+    -> Name Owner      -- ^ owner
+    -> Name Repo       -- ^ repository name
+    -> UpdateFile
+    -> IO (Either Error Content)
+updateFile auth user repo body =
+    executeRequest auth $ updateFileR user repo body
+
+-- | Update a file.
+-- See <https://developer.github.com/v3/repos/contents/#update-a-file>
+updateFileR
+    :: Name Owner
+    -> Name Repo
+    -> UpdateFile
+    -> Request 'RW Content
+updateFileR user repo body =
+    command Put ["repos", toPathPart user, toPathPart repo, "contents", updateFilePath body] (encode body)
+
+-- | Delete a file.
+deleteFile
+    :: Auth
+    -> Name Owner      -- ^ owner
+    -> Name Repo       -- ^ repository name
+    -> DeleteFile
+    -> IO (Either Error ())
+deleteFile auth user repo body =
+    executeRequest auth $ deleteFileR user repo body
+
+-- | Delete a file.
+-- See <https://developer.github.com/v3/repos/contents/#delete-a-file>
+deleteFileR
+    :: Name Owner
+    -> Name Repo
+    -> DeleteFile
+    -> Request 'RW ()
+deleteFileR user repo body =
+    command Delete ["repos", toPathPart user, toPathPart repo, "contents", deleteFilePath body] (encode body)

--- a/src/GitHub/Endpoints/Repos/Contents.hs
+++ b/src/GitHub/Endpoints/Repos/Contents.hs
@@ -85,7 +85,7 @@ createFile
     -> Name Owner      -- ^ owner
     -> Name Repo       -- ^ repository name
     -> CreateFile
-    -> IO (Either Error Content)
+    -> IO (Either Error ContentResult)
 createFile auth user repo body =
     executeRequest auth $ createFileR user repo body
 
@@ -95,7 +95,7 @@ createFileR
     :: Name Owner
     -> Name Repo
     -> CreateFile
-    -> Request 'RW Content
+    -> Request 'RW ContentResult
 createFileR user repo body =
     command Put ["repos", toPathPart user, toPathPart repo, "contents", createFilePath body] (encode body)
 
@@ -105,7 +105,7 @@ updateFile
     -> Name Owner      -- ^ owner
     -> Name Repo       -- ^ repository name
     -> UpdateFile
-    -> IO (Either Error Content)
+    -> IO (Either Error ContentResult)
 updateFile auth user repo body =
     executeRequest auth $ updateFileR user repo body
 
@@ -115,7 +115,7 @@ updateFileR
     :: Name Owner
     -> Name Repo
     -> UpdateFile
-    -> Request 'RW Content
+    -> Request 'RW ContentResult
 updateFileR user repo body =
     command Put ["repos", toPathPart user, toPathPart repo, "contents", updateFilePath body] (encode body)
 

--- a/src/GitHub/Endpoints/Repos/Contents.hs
+++ b/src/GitHub/Endpoints/Repos/Contents.hs
@@ -24,7 +24,9 @@ module GitHub.Endpoints.Repos.Contents (
 
     -- ** Delete
     deleteFile,
-    deleteFileR
+    deleteFileR,
+
+    module GitHub.Data
     ) where
 
 import GitHub.Data

--- a/src/GitHub/Endpoints/Repos/Contents.hs
+++ b/src/GitHub/Endpoints/Repos/Contents.hs
@@ -1,0 +1,59 @@
+module GitHub.Endpoints.Repos.Contents (
+    -- * Querying repositories
+    contentsFor,
+    contentsFor',
+    contentsForR,
+    readmeFor,
+    readmeFor',
+    readmeForR
+    ) where
+
+import GitHub.Data
+import GitHub.Internal.Prelude
+import GitHub.Request
+import Prelude ()
+
+import qualified Data.Text.Encoding as TE
+
+-- | The contents of a file or directory in a repo, given the repo owner, name, and path to the file
+--
+-- > contentsFor "thoughtbot" "paperclip" "README.md"
+contentsFor :: Name Owner -> Name Repo -> Text -> Maybe Text -> IO (Either Error Content)
+contentsFor = contentsFor' Nothing
+
+-- | The contents of a file or directory in a repo, given the repo owner, name, and path to the file
+-- With Authentication
+--
+-- > contentsFor' (Just (BasicAuth (user, password))) "thoughtbot" "paperclip" "README.md" Nothing
+contentsFor' :: Maybe Auth ->  Name Owner -> Name Repo -> Text -> Maybe Text -> IO (Either Error Content)
+contentsFor' auth user repo path ref =
+    executeRequestMaybe auth $ contentsForR user repo path ref
+
+contentsForR
+    :: Name Owner
+    -> Name Repo
+    -> Text            -- ^ file or directory
+    -> Maybe Text      -- ^ Git commit
+    -> Request k Content
+contentsForR user repo path ref =
+    query ["repos", toPathPart user, toPathPart repo, "contents", path] qs
+  where
+    qs =  maybe [] (\r -> [("ref", Just . TE.encodeUtf8 $ r)]) ref
+
+-- | The contents of a README file in a repo, given the repo owner and name
+--
+-- > readmeFor "thoughtbot" "paperclip"
+readmeFor :: Name Owner -> Name Repo -> IO (Either Error Content)
+readmeFor = readmeFor' Nothing
+
+-- | The contents of a README file in a repo, given the repo owner and name
+-- With Authentication
+--
+-- > readmeFor' (Just (BasicAuth (user, password))) "thoughtbot" "paperclip"
+readmeFor' :: Maybe Auth -> Name Owner -> Name Repo -> IO (Either Error Content)
+readmeFor' auth user repo =
+    executeRequestMaybe auth $ readmeForR user repo
+
+readmeForR :: Name Owner -> Name Repo -> Request k Content
+readmeForR user repo =
+    query ["repos", toPathPart user, toPathPart repo, "readme"] []


### PR DESCRIPTION
This adds the create, update and delete file endpoints from https://developer.github.com/v3/repos/contents/

The code in the PR works great.

I would say it's about 80% done in terms of the coding guidelines. Still to be done are updating the contents example from the samples (which is also out of date with respect to the current master branch). I wanted to wait to update those until I got approval on the current code structure.

I am opening the Pull Request now to get feedback on some of the code organizational choices and naming choices. I am happy to change them to whatever you think best. I am not particularly attached to my choices so far--I mainly picked what seemed to be a reasonably good start.

In particular I added a new module called `GitHub.Endpoints.Repos.Contents`. This mirrors the structure of the GitHub API.

I also moved `contentFor` and related functions to the new module, since they are located there in the GitHub API.

I added the new endpoints to the same module.

I added new datatypes to the module `GitHub.Data.Content` because that seemed like the best fit so far.

