### PR TITLE
Add endpoints for (un)starring repositories

### DIFF
--- a/samples/Activity/Starring/StarRepo.hs
+++ b/samples/Activity/Starring/StarRepo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+module StarRepo where
+
+import qualified GitHub.Endpoints.Activity.Starring as GH
+
+import qualified Data.Text    as T
+import qualified Data.Text.IO as T
+
+main :: IO ()
+main = do
+    let owner = "phadej"
+        repo  = "github"
+    result <- GH.starRepo (GH.OAuth "your-token")
+        (GH.mkOwnerName owner) (GH.mkRepoName repo)
+    case result of
+        Left err ->   putStrLn $ "Error: " ++ show err
+        Right () -> T.putStrLn $ T.concat ["Starred: ", owner, "/", repo]

--- a/samples/Activity/Starring/UnstarRepo.hs
+++ b/samples/Activity/Starring/UnstarRepo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+module UnstarRepo where
+
+import qualified GitHub.Endpoints.Activity.Starring as GH
+
+import qualified Data.Text    as T
+import qualified Data.Text.IO as T
+
+main :: IO ()
+main = do
+    let owner = "phadej"
+        repo  = "github"
+    result <- GH.unstarRepo (GH.OAuth "your-token")
+        (GH.mkOwnerName owner) (GH.mkRepoName repo)
+    case result of
+        Left err ->   putStrLn $ "Error: " ++ show err
+        Right () -> T.putStrLn $ T.concat ["Unstarred: ", owner, "/", repo]

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -25,12 +25,12 @@ module GitHub (
     -- Missing endpoints:
     --
     -- * Check if you are starring a repository
-    -- * Star a repository
-    -- * Unstar a repository
     stargazersForR,
     reposStarredByR,
     myStarredR,
     myStarredAcceptStarR,
+    starRepoR,
+    unstarRepoR,
 
     -- ** Watching
     -- | See <https://developer.github.com/v3/activity/>

--- a/src/GitHub/Endpoints/Activity/Starring.hs
+++ b/src/GitHub/Endpoints/Activity/Starring.hs
@@ -14,6 +14,10 @@ module GitHub.Endpoints.Activity.Starring (
     myStarredR,
     myStarredAcceptStar,
     myStarredAcceptStarR,
+    starRepo,
+    starRepoR,
+    unstarRepo,
+    unstarRepoR,
     module GitHub.Data,
     ) where
 
@@ -69,3 +73,25 @@ myStarredAcceptStar auth =
 -- See <https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps-1>
 myStarredAcceptStarR :: FetchCount -> Request 'RA (Vector RepoStarred)
 myStarredAcceptStarR = HeaderQuery [("Accept", "application/vnd.github.v3.star+json")] . PagedQuery ["user", "starred"] []
+
+-- | Star a repo by the authenticated user.
+starRepo :: Auth -> Name Owner -> Name Repo -> IO (Either Error ())
+starRepo auth user repo = executeRequest auth $ starRepoR user repo
+
+-- | Star a repo by the authenticated user.
+-- See <https://developer.github.com/v3/activity/starring/#star-a-repository>
+starRepoR :: Name Owner -> Name Repo -> Request 'RW ()
+starRepoR user repo = command Put' paths mempty
+  where
+    paths = ["user", "starred", toPathPart user, toPathPart repo]
+
+-- | Unstar a repo by the authenticated user.
+unstarRepo :: Auth -> Name Owner -> Name Repo -> IO (Either Error ())
+unstarRepo auth user repo = executeRequest auth $ unstarRepoR user repo
+
+-- | Unstar a repo by the authenticated user.
+-- See <https://developer.github.com/v3/activity/starring/#unstar-a-repository>
+unstarRepoR :: Name Owner -> Name Repo -> Request 'RW ()
+unstarRepoR user repo = command Delete paths mempty
+  where
+    paths = ["user", "starred", toPathPart user, toPathPart repo]


### PR DESCRIPTION
This PR is for creating API endpoints to star/unstar repositories.

* https://developer.github.com/v3/activity/starring/#star-a-repository
* https://developer.github.com/v3/activity/starring/#unstar-a-repository

I added not tests but samples under `samples/Activity/Starring/`, because the endpoints have side-effects.