### PR TITLE
Add endpoints for (un)starring gists

### DIFF
--- a/samples/Gists/StarGist.hs
+++ b/samples/Gists/StarGist.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module StarGist where
+
+import qualified GitHub.Data.Name       as N
+import qualified GitHub.Endpoints.Gists as GH
+
+import qualified Data.Text    as T
+import qualified Data.Text.IO as T
+
+main :: IO ()
+main = do
+    let gid = "your-gist-id"
+    result <- GH.starGist (GH.OAuth "your-token") gid
+    case result of
+        Left err ->   putStrLn $ "Error: " ++ show err
+        Right () -> T.putStrLn $ T.concat ["Starred: ", N.untagName gid]

--- a/samples/Gists/UnstarGist.hs
+++ b/samples/Gists/UnstarGist.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module UnstarGist where
+
+import qualified GitHub.Data.Name       as N
+import qualified GitHub.Endpoints.Gists as GH
+
+import qualified Data.Text    as T
+import qualified Data.Text.IO as T
+
+main :: IO ()
+main = do
+    let gid = "your-gist-id"
+    result <- GH.unstarGist (GH.OAuth "your-token") gid
+    case result of
+        Left err ->   putStrLn $ "Error: " ++ show err
+        Right () -> T.putStrLn $ T.concat ["Unstarred: ", N.untagName gid]

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -52,13 +52,13 @@ module GitHub (
     -- * Create a gist
     -- * Edit a gist
     -- * List gist commits
-    -- * Star a gist
-    -- * Unstar a gist
     -- * Check if a gist is starred
     -- * Fork a gist
     -- * List gist forks
     gistsR,
     gistR,
+    starGistR,
+    unstarGistR,
     deleteGistR,
 
     -- ** Comments

--- a/src/GitHub/Endpoints/Gists.hs
+++ b/src/GitHub/Endpoints/Gists.hs
@@ -11,6 +11,10 @@ module GitHub.Endpoints.Gists (
     gist,
     gist',
     gistR,
+    starGist,
+    starGistR,
+    unstarGist,
+    unstarGistR,
     deleteGist,
     deleteGistR,
     module GitHub.Data,
@@ -57,6 +61,28 @@ gist = gist' Nothing
 gistR :: Name Gist -> Request k Gist
 gistR gid =
     query ["gists", toPathPart gid] []
+
+-- | Star a gist by the authenticated user.
+--
+-- > starGist ("github-username", "github-password") "225074"
+starGist :: Auth -> Name Gist -> IO (Either Error ())
+starGist auth gid = executeRequest auth $ starGistR gid
+
+-- | Star a gist by the authenticated user.
+-- See <https://developer.github.com/v3/gists/#star-a-gist>
+starGistR :: Name Gist -> Request 'RW ()
+starGistR gid = command Put' ["gists", toPathPart gid, "star"] mempty
+
+-- | Unstar a gist by the authenticated user.
+--
+-- > unstarGist ("github-username", "github-password") "225074"
+unstarGist :: Auth -> Name Gist -> IO (Either Error ())
+unstarGist auth gid = executeRequest auth $ unstarGistR gid
+
+-- | Unstar a gist by the authenticated user.
+-- See <https://developer.github.com/v3/gists/#unstar-a-gist>
+unstarGistR :: Name Gist -> Request 'RW ()
+unstarGistR gid = command Delete ["gists", toPathPart gid, "star"] mempty
 
 -- | Delete a gist by the authenticated user.
 --


### PR DESCRIPTION
This PR is for creating API endpoints to star/unstar gists.

https://developer.github.com/v3/gists/#star-a-gist
https://developer.github.com/v3/gists/#unstar-a-gist

I added not tests but samples under samples/Gists, because the endpoints have side-effects.