### PR TITLE
Add endpoints for deleting gists

### DIFF
--- a/samples/Gists/DeleteGist.hs
+++ b/samples/Gists/DeleteGist.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module DeleteGist where
+
+import qualified GitHub.Data.Name       as N
+import qualified GitHub.Endpoints.Gists as GH
+
+import qualified Data.Text    as T
+import qualified Data.Text.IO as T
+
+main :: IO ()
+main = do
+    let gid = "your-gist-id"
+    result <- GH.deleteGist (GH.OAuth "your-token") gid
+    case result of
+        Left err ->   putStrLn $ "Error: " ++ show err
+        Right () -> T.putStrLn $ T.concat ["Deleted: ", N.untagName gid]

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -57,9 +57,9 @@ module GitHub (
     -- * Check if a gist is starred
     -- * Fork a gist
     -- * List gist forks
-    -- * Delete a gist
     gistsR,
     gistR,
+    deleteGistR,
 
     -- ** Comments
     -- | See <https://developer.github.com/v3/gists/comments/>

--- a/src/GitHub/Endpoints/Gists.hs
+++ b/src/GitHub/Endpoints/Gists.hs
@@ -11,6 +11,8 @@ module GitHub.Endpoints.Gists (
     gist,
     gist',
     gistR,
+    deleteGist,
+    deleteGistR,
     module GitHub.Data,
     ) where
 
@@ -55,3 +57,14 @@ gist = gist' Nothing
 gistR :: Name Gist -> Request k Gist
 gistR gid =
     query ["gists", toPathPart gid] []
+
+-- | Delete a gist by the authenticated user.
+--
+-- > deleteGist ("github-username", "github-password") "225074"
+deleteGist :: Auth -> Name Gist -> IO (Either Error ())
+deleteGist auth gid = executeRequest auth $ deleteGistR gid
+
+-- | Delete a gist by the authenticated user.
+-- See <https://developer.github.com/v3/gists/#delete-a-gist>
+deleteGistR :: Name Gist -> Request 'RW ()
+deleteGistR gid = command Delete ["gists", toPathPart gid] mempty


### PR DESCRIPTION
This PR is for creating an API endpoint to delete gists.

https://developer.github.com/v3/gists/#delete-a-gist

I added a sample as `samples/Gists/DeleteGist.hs`.
