### PR TITLE
userRepo should be repository

### DIFF
--- a/samples/Repos/ShowRepo.hs
+++ b/samples/Repos/ShowRepo.hs
@@ -5,7 +5,7 @@ import Data.List
 import Data.Maybe
 
 main = do
-  possibleRepo <- Github.userRepo "mike-burns" "trylambda"
+  possibleRepo <- Github.repository "mike-burns" "trylambda"
   case possibleRepo of
        (Left error) -> putStrLn $ "Error: " ++ (show error)
        (Right repo) -> putStrLn $ formatRepo repo

--- a/src/GitHub/Endpoints/Repos.hs
+++ b/src/GitHub/Endpoints/Repos.hs
@@ -136,14 +136,14 @@ organizationReposR org publicity =
 
 -- | Details on a specific repo, given the owner and repo name.
 --
--- > userRepo "mike-burns" "github"
+-- > repository "mike-burns" "github"
 repository :: Name Owner -> Name Repo -> IO (Either Error Repo)
 repository = repository' Nothing
 
 -- | Details on a specific repo, given the owner and repo name.
 -- With authentication.
 --
--- > userRepo' (Just (BasicAuth (user, password))) "mike-burns" "github"
+-- > repository' (Just (BasicAuth (user, password))) "mike-burns" "github"
 repository' :: Maybe Auth -> Name Owner -> Name Repo -> IO (Either Error Repo)
 repository' auth user repo =
     executeRequestMaybe auth $ repositoryR user repo


### PR DESCRIPTION
`userRepo` was renamed `repository` a while ago, but the documentation and the samples still referred to/used `userRepo`.