### PR TITLE
Make "repo" in PullRequestCommit nullable.

### DIFF
--- a/src/GitHub/Data/PullRequests.hs
+++ b/src/GitHub/Data/PullRequests.hs
@@ -136,7 +136,7 @@ data PullRequestCommit = PullRequestCommit
     , pullRequestCommitRef   :: !Text
     , pullRequestCommitSha   :: !Text
     , pullRequestCommitUser  :: !SimpleUser
-    , pullRequestCommitRepo  :: !Repo
+    , pullRequestCommitRepo  :: !(Maybe Repo)
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 


### PR DESCRIPTION
In rare cases, the repo can become null.

Fixes #310.