### PR TITLE
Fixing isPullRequestMerged and other boolean responses and adding check membership API

### DIFF
--- a/spec/GitHub/PullRequestsSpec.hs
+++ b/spec/GitHub/PullRequestsSpec.hs
@@ -3,6 +3,7 @@
 module GitHub.PullRequestsSpec where
 
 import qualified GitHub
+import GitHub.Data.Id (Id(Id))
 
 import Prelude ()
 import Prelude.Compat
@@ -50,6 +51,13 @@ spec = do
 
             V.length (GitHub.pullRequestRequestedReviewers pullRequestReviewRequested)
                 `shouldBe` 1
+
+    describe "checking if a pull request is merged" $ do
+        it "works" $ withAuth $ \auth -> do
+            b <- GitHub.executeRequest auth $ GitHub.isPullRequestMergedR "phadej" "github" (Id 14)
+            b `shouldSatisfy` isRight
+            fromRightS b `shouldBe` True
+
   where
     repos =
       [ ("thoughtbot", "paperclip")

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -158,9 +158,10 @@ module GitHub (
     -- ** Members
     -- | See <https://developer.github.com/v3/orgs/members/>
     --
-    -- Missing endpoints: All except /Members List/
+    -- Missing endpoints: All except /Members List/ and /Check Membership/
     membersOfR,
     membersOfWithR,
+    isMemberOfR,
 
     -- ** Teams
     -- | See <https://developer.github.com/v3/orgs/teams/>

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -158,7 +158,7 @@ type StatusMap a = [(Int, a)]
 
 statusOnlyOk :: StatusMap Bool
 statusOnlyOk =
-    [ (202, True)
+    [ (204, True)
     , (404, False)
     ]
 

--- a/src/GitHub/Endpoints/Organizations/Members.hs
+++ b/src/GitHub/Endpoints/Organizations/Members.hs
@@ -10,6 +10,9 @@ module GitHub.Endpoints.Organizations.Members (
     membersOf',
     membersOfR,
     membersOfWithR,
+    isMemberOf,
+    isMemberOf',
+    isMemberOfR,
     module GitHub.Data,
     ) where
 
@@ -54,3 +57,25 @@ membersOfWithR org f r =
         OrgMemberRoleAll    -> "all"
         OrgMemberRoleAdmin  -> "admin"
         OrgMemberRoleMember -> "member"
+
+-- | Check if a user is a member of an organization,
+-- | with or without authentication.
+--
+-- > isMemberOf' (Just $ OAuth "token") "phadej" "haskell-infra"
+isMemberOf' :: Maybe Auth -> Name User -> Name Organization -> IO (Either Error Bool)
+isMemberOf' auth user org =
+    executeRequestMaybe auth $ isMemberOfR user org
+
+-- | Check if a user is a member of an organization,
+-- | without authentication.
+--
+-- > isMemberOf "phadej" "haskell-infra"
+isMemberOf :: Name User -> Name Organization -> IO (Either Error Bool)
+isMemberOf = isMemberOf' Nothing
+
+-- | Check if a user is a member of an organization.
+--
+-- See <https://developer.github.com/v3/orgs/members/#check-membership>
+isMemberOfR :: Name User -> Name Organization -> Request k Bool
+isMemberOfR user org = StatusQuery statusOnlyOk $
+    Query [ "orgs", toPathPart org, "members", toPathPart user ] []


### PR DESCRIPTION
This seems to be an unreported bug. Github returns http 204 and not 202 for "check/get if so on and so forth" type predicates and test/ping requests. At least all four exposed in this library return http 204 on success:

- [check if a user is a collaborator](https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator)
- [get if a pull request has been merged](https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged)
- [test a push hook](https://developer.github.com/v3/repos/hooks/#test-a-push-hook)
- [ping a hook](https://developer.github.com/v3/repos/hooks/#ping-a-hook)

I added a test for the second case since it's the most easily tested scenario.