### PR TITLE
Feature/create pull comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cabal.sandbox.config
 run.sh
 src/hightlight.js
 src/style.css
+tags

--- a/src/GitHub/Data/Comments.hs
+++ b/src/GitHub/Data/Comments.hs
@@ -56,7 +56,7 @@ instance ToJSON NewComment where
 
 data NewPullComment = NewPullComment
     { newPullCommentCommit :: !Text
-    , newPulLCommentPath :: !Text
+    , newPullCommentPath :: !Text
     , newPullCommentPosition :: !Int
     , newPullCommentBody :: !Text
     }

--- a/src/GitHub/Data/Comments.hs
+++ b/src/GitHub/Data/Comments.hs
@@ -54,6 +54,25 @@ instance Binary NewComment
 instance ToJSON NewComment where
     toJSON (NewComment b) = object [ "body" .= b ]
 
+data NewPullComment = NewPullComment
+    { newPullCommentCommit :: !Text
+    , newPulLCommentPath :: !Text
+    , newPullCommentPosition :: !Int
+    , newPullCommentBody :: !Text
+    }
+  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData NewPullComment where rnf = genericRnf
+instance Binary NewPullComment
+
+instance ToJSON NewPullComment where
+    toJSON (NewPullComment c path pos b) =
+        object [ "body" .= b
+               , "commit_id" .= c
+               , "path" .= path
+               , "position" .= pos
+               ]
+
 data EditComment = EditComment
     { editCommentBody :: !Text
     }

--- a/src/GitHub/Endpoints/PullRequests.hs
+++ b/src/GitHub/Endpoints/PullRequests.hs
@@ -12,6 +12,9 @@ module GitHub.Endpoints.PullRequests (
     pullRequest',
     pullRequest,
     pullRequestR,
+    pullRequestDiff',
+    pullRequestDiff,
+    pullRequestDiffR,
     createPullRequest,
     createPullRequestR,
     updatePullRequest,
@@ -33,6 +36,7 @@ import GitHub.Data
 import GitHub.Internal.Prelude
 import GitHub.Request
 import Prelude ()
+import Data.ByteString.Lazy (ByteString)
 
 -- | All open pull requests for the repo, by owner and repo name.
 --
@@ -59,6 +63,25 @@ pullRequestsForR
 pullRequestsForR user repo opts = pagedQuery
     ["repos", toPathPart user, toPathPart repo, "pulls"]
     (prModToQueryString opts)
+
+-- | Obtain the diff of a pull request
+-- See <https://developer.github.com/v3/pulls/#get-a-single-pull-request>
+pullRequestDiff' :: Maybe Auth -> Name Owner -> Name Repo -> Id PullRequest -> IO (Either Error ByteString)
+pullRequestDiff' auth user repo prid =
+    executeRequestMaybe auth $ pullRequestDiffR user repo prid
+
+-- | Obtain the diff of a pull request
+-- See <https://developer.github.com/v3/pulls/#get-a-single-pull-request>
+pullRequestDiff :: Name Owner -> Name Repo -> Id PullRequest -> IO (Either Error ByteString)
+pullRequestDiff = pullRequestDiff' Nothing
+
+-- | Query a single pull request to obtain the diff
+-- See <https://developer.github.com/v3/pulls/#get-a-single-pull-request>
+pullRequestDiffR :: Name Owner -> Name Repo -> Id PullRequest -> Request k ByteString
+pullRequestDiffR user repo prid =
+    RawHeaderQuery
+        [("Accept", "application/vnd.github.v3.diff")]
+        (Query ["repos", toPathPart user, toPathPart repo, "pulls", toPathPart prid] []) -- XXX change the accept header here
 
 -- | A detailed pull request, which has much more information. This takes the
 -- repo owner and name along with the number assigned to the pull request.

--- a/src/GitHub/Endpoints/PullRequests/Comments.hs
+++ b/src/GitHub/Endpoints/PullRequests/Comments.hs
@@ -59,6 +59,6 @@ createPullComment auth user repo iss commit path position body =
 -- See <https://developer.github.com/v3/pulls/comments/#create-a-comment>
 createPullCommentR :: Name Owner -> Name Repo -> Id Issue -> Text -> Text -> Int -> Text -> Request 'RW Comment
 createPullCommentR user repo iss commit path position body =
-    command Post parts (encode $ NewComment body)
+    command Post parts (encode $ NewPullComment commit path position body)
   where
     parts = ["repos", toPathPart user, toPathPart repo, "pulls", toPathPart iss, "comments"]

--- a/src/GitHub/Endpoints/PullRequests/Comments.hs
+++ b/src/GitHub/Endpoints/PullRequests/Comments.hs
@@ -10,7 +10,9 @@ module GitHub.Endpoints.PullRequests.Comments (
     pullRequestCommentsR,
     pullRequestComment,
     pullRequestCommentR,
-    module GitHub.Data,
+    createPullComment,
+    createPullCommentR,
+    module GitHub.Data
     ) where
 
 import GitHub.Data
@@ -43,3 +45,20 @@ pullRequestComment user repo cid =
 pullRequestCommentR :: Name Owner -> Name Repo -> Id Comment -> Request k Comment
 pullRequestCommentR user repo cid =
     query ["repos", toPathPart user, toPathPart repo, "pulls", "comments", toPathPart cid] []
+
+-- | Create a new comment.
+--
+-- > createPullComment (User (user, password)) user repo issue commit path position
+-- >  "some words"
+createPullComment :: Auth -> Name Owner -> Name Repo -> Id Issue -> Text -> Text -> Int -> Text
+            -> IO (Either Error Comment)
+createPullComment auth user repo iss commit path position body =
+    executeRequest auth $ createPullCommentR user repo iss commit path position body
+
+-- | Create a comment.
+-- See <https://developer.github.com/v3/pulls/comments/#create-a-comment>
+createPullCommentR :: Name Owner -> Name Repo -> Id Issue -> Text -> Text -> Int -> Text -> Request 'RW Comment
+createPullCommentR user repo iss commit path position body =
+    command Post parts (encode $ NewComment body)
+  where
+    parts = ["repos", toPathPart user, toPathPart repo, "pulls", toPathPart iss, "comments"]


### PR DESCRIPTION
This PR is actually two concepts for us to discuss and merge or rework depending on the outcome of the discussion.

# Pull Request Line Comments

We now have `NewPullComment` and `createPullComment :: Auth -> Name Owner -> Name Repo -> Id Issue -> Text -> Text -> Int -> Text -> IO (Either Error Comment)`  where we have a commit hash, file path, position, and a body.

# Pull Request Diffs

Obtaining pull request diffs (github diffs) requires use of a new accept header.  The diff provided via a URL is not a git diff and therefore unsuitable for calculating line numbers for the position value needed by `createPullComment`.