### PR TITLE
Partial escape in query string to make search work again

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -1,5 +1,6 @@
 name:                github
 version:             0.19
+x-revision:          2
 synopsis:            Access to the GitHub API, v3.
 description:
   The GitHub API provides programmatic access to the full

--- a/github.cabal
+++ b/github.cabal
@@ -1,6 +1,5 @@
 name:                github
 version:             0.19
-x-revision:          2
 synopsis:            Access to the GitHub API, v3.
 description:
   The GitHub API provides programmatic access to the full
@@ -146,7 +145,7 @@ Library
   -- other packages
   build-depends:
     aeson                 >=0.7.0.6   && <1.4,
-    base-compat           >=0.9.1     && <0.11,
+    base-compat           >=0.9.1     && <0.10,
     base16-bytestring     >=0.1.1.6   && <0.2,
     binary                >=0.7.1.0   && <0.10,
     binary-orphans        >=0.1.0.0   && <0.2,
@@ -155,7 +154,7 @@ Library
     deepseq-generics      >=0.1.1.2   && <0.3,
     exceptions            >=0.8.0.2   && <0.11,
     hashable              >=1.2.3.3   && <1.3,
-    http-client           >=0.4.8.1   && <0.6,
+    http-client           >=0.5.10    && <0.6,
     http-client-tls       >=0.2.2     && <0.4,
     http-link-header      >=1.0.1     && <1.1,
     http-types            >=0.12.1    && <0.13,

--- a/github.cabal
+++ b/github.cabal
@@ -146,7 +146,7 @@ Library
   -- other packages
   build-depends:
     aeson                 >=0.7.0.6   && <1.4,
-    base-compat           >=0.9.1     && <0.10,
+    base-compat           >=0.9.1     && <0.11,
     base16-bytestring     >=0.1.1.6   && <0.2,
     binary                >=0.7.1.0   && <0.10,
     binary-orphans        >=0.1.0.0   && <0.2,

--- a/samples/Search/AllHaskellRepos.hs
+++ b/samples/Search/AllHaskellRepos.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+module AllHaskellRepos where
+import           Control.Monad(when)
+import           Data.List(group, sort)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Vector as V
+import           Data.Time.Calendar(addDays, Day(..), showGregorian)
+import           Data.Time.Clock(getCurrentTime, UTCTime(..))
+import           Data.Time.Format(parseTimeM, defaultTimeLocale, iso8601DateFormat)
+import           Time.System(dateCurrent)
+import           GitHub.Auth(Auth(..))
+import           GitHub.Endpoints.Search(searchRepos', SearchResult(..), EscapeItem(..),
+                                         searchIssues')
+import           GitHub.Data.Repos
+import           GitHub.Data.Definitions
+import           GitHub.Data.Name
+import           GitHub.Data.URL
+import           GitHub.Data.Options(SearchRepoMod(..), SearchRepoOptions(..), Language(..),
+                                     License(..), StarsForksUpdated(..), SortDirection(..),
+                                     searchRepoModToQueryString)
+import           System.FilePath.Posix(FilePath)
+import Debug.Trace
+
+-- | A search query finds all Haskell libraries on github
+--   and updates two files of all packages/authors
+updateGithub :: [FilePath] -> IO ()
+updateGithub [lastIntervalEnd, authorsCsv, packagesCsv] = do
+  lastEnd <- T.readFile lastIntervalEnd -- first time: 2008-03-01
+  start <- parseTimeM True defaultTimeLocale (iso8601DateFormat Nothing) (T.unpack lastEnd)
+  intervals pass start 10 -- stop after 10 queries
+  a <- T.readFile authorsCsv
+  T.writeFile authorsCsv  (dups a)
+  p <- T.readFile packagesCsv
+  T.writeFile packagesCsv (dups p)
+ where
+  dups = T.unlines . map head . group . sort . T.lines
+  -- Go through all github repos, by chosing small time intervals
+  intervals :: String -> Day -> Int -> IO ()
+  intervals pass start i = do
+    let newDate = addDays 10 start -- assuming less than 100 repos in 10 days
+
+    -- Remember the last succesfully scanned interval 
+    -- (to update the list and continue when query timeout reached or query failed)
+    T.writeFile lastIntervalEnd (T.pack (showGregorian newDate))
+
+-- https://api.github.com/search/repositories?q=language:haskell+created:2009-01-01..2009-02-01&sort=stars&order=desc
+    let query search = search { searchRepoOptionsLanguage = Just (Language "Haskell")
+                              , searchRepoOptionsSortBy   = Just Stars
+                              , searchRepoOptionsOrder    = Just SortDescending
+                              , searchRepoOptionsCreated  = Just (start, newDate)
+                              }
+    res <- searchRepos' (Just $ BasicAuth "user" "pass") (SearchRepoMod query)
+    either (\_-> return ()) appendToCSV res
+--    putStrLn (show res) -- for debugging
+    currentDate <- fmap utctDay getCurrentTime
+    when (newDate < currentDate && i>0) (intervals pass newDate (i-1))
+
+  appendToCSV :: SearchResult Repo -> IO ()
+  appendToCSV res = do
+    V.mapM_ extractFromRepo (searchResultResults res)
+   where
+    extractFromRepo r = do
+      T.appendFile authorsCsv  (untagName (simpleOwnerLogin (repoOwner r)) `T.append` "\n")
+      T.appendFile packagesCsv (getUrl (repoHtmlUrl r) `T.append` "\n")
+

--- a/src/GitHub/Data/Definitions.hs
+++ b/src/GitHub/Data/Definitions.hs
@@ -15,6 +15,7 @@ import Network.HTTP.Client (HttpException)
 import qualified Control.Exception as E
 import qualified Data.ByteString   as BS
 import qualified Data.Text         as T
+import qualified Network.HTTP.Types as W
 
 import GitHub.Data.Id   (Id)
 import GitHub.Data.Name (Name)
@@ -232,7 +233,7 @@ data OrgMemberRole
     deriving (Show, Eq, Ord, Enum, Bounded, Typeable, Data, Generic)
 
 -- | Request query string
-type QueryString = [(BS.ByteString, Maybe BS.ByteString)]
+type QueryString = [(BS.ByteString, [W.EscapeItem])]
 
 -- | Count of elements
 type Count = Int

--- a/src/GitHub/Data/Options.hs
+++ b/src/GitHub/Data/Options.hs
@@ -44,6 +44,14 @@ module GitHub.Data.Options (
     optionsIrrelevantAssignee,
     optionsAnyAssignee,
     optionsNoAssignee,
+    -- * Repo Search
+    SearchRepoMod(..),
+    searchRepoModToQueryString,
+    SearchRepoOptions(..),
+    SortDirection(..),
+    License(..),
+    Language(..),
+    StarsForksUpdated(..),
     -- * Data
     IssueState (..),
     MergeableState (..),
@@ -56,13 +64,16 @@ module GitHub.Data.Options (
     HasSince,
     ) where
 
+import Data.Time.Calendar      (Day, showGregorian)
 import GitHub.Data.Definitions
 import GitHub.Data.Id          (Id, untagId)
 import GitHub.Data.Milestone   (Milestone)
 import GitHub.Data.Name        (Name, untagName)
+import GitHub.Data.Repos       (Language(..))
 import GitHub.Internal.Prelude
 import Prelude ()
 
+import qualified Network.HTTP.Types as W
 import qualified Data.Text          as T
 import qualified Data.Text.Encoding as TE
 
@@ -298,7 +309,7 @@ pullRequestOptionsToQueryString (PullRequestOptions st head_ base sort dir) =
     , mk "base" <$> base'
     ]
   where
-    mk k v = (k, Just v)
+    mk k v = (k, [W.QE v])
     state' = case st of
         Nothing          -> "all"
         Just StateOpen   -> "open"
@@ -395,7 +406,7 @@ issueOptionsToQueryString (IssueOptions filt st labels sort dir since) =
     , mk "since" <$> since'
     ]
   where
-    mk k v = (k, Just v)
+    mk k v = (k, [W.QE v])
     filt' = case filt of
         IssueFilterAssigned   -> "assigned"
         IssueFilterCreated    -> "created"
@@ -543,7 +554,7 @@ issueRepoOptionsToQueryString IssueRepoOptions {..} =
     , mk "mentioned" <$> mentioned'
     ]
   where
-    mk k v = (k, Just v)
+    mk k v = (k, [W.QE v])
     filt f x = case x of
         FilterAny          -> Just "*"
         FilterNone         -> Just "none"
@@ -602,3 +613,142 @@ optionsAnyAssignee = IssueRepoMod $ \opts ->
 optionsNoAssignee :: IssueRepoMod
 optionsNoAssignee = IssueRepoMod $ \opts ->
     opts { issueRepoOptionsAssignee = FilterNone }
+
+------------------------------------------------------------------------------------
+-- SearchRepo Options
+------------------------------------------------------------------------------------
+
+data StarsForksUpdated
+    = Stars
+    | Forks
+    | Updated
+  deriving
+    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+
+instance ToJSON StarsForksUpdated where
+    toJSON Stars = String "stars"
+    toJSON Forks = String "forks"
+    toJSON Updated = String "updated"
+
+instance FromJSON StarsForksUpdated where
+    parseJSON (String "stars") = pure Stars
+    parseJSON (String "forks") = pure Forks
+    parseJSON (String "updated") = pure Updated
+    parseJSON v                 = typeMismatch "StarsForksUpdated" v
+
+newtype License = License Text
+   deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+data RepoUser = Repo | User
+  deriving
+    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+
+data RepoIn = RName | RDescription | Readme
+  deriving
+    (Eq, Ord, Show, Enum, Bounded, Generic, Typeable, Data)
+
+type Topic = String
+
+data SearchRepoOptions = SearchRepoOptions
+    { searchRepoOptionsKeyword  :: !Text
+    , searchRepoOptionsSortBy   :: !(Maybe StarsForksUpdated)
+    , searchRepoOptionsOrder    :: !(Maybe SortDirection)
+    , searchRepoOptionsCreated  :: !(Maybe (Day, Day)) -- period
+    , searchRepoOptionsPushed   :: !(Maybe (Day, Day))
+    , searchRepoOptionsFork     :: !(Maybe Bool)
+    , searchRepoOptionsForks    :: !(Maybe Int)
+    , searchRepoOptionsIn       :: !(Maybe RepoIn)
+    , searchRepoOptionsLanguage :: !(Maybe Language)
+    , searchRepoOptionsLicense  :: !(Maybe License)
+    , searchRepoOptionsRepoUser :: !(Maybe RepoUser)
+    , searchRepoOptionsSize     :: !(Maybe Int)
+    , searchRepoOptionsStars    :: !(Maybe Int)
+    , searchRepoOptionsTopic    :: !(Maybe Topic)
+    , searchRepoOptionsArchived :: !(Maybe Bool)
+    }
+  deriving
+    (Eq, Ord, Show, Generic, Typeable, Data)
+
+defaultSearchRepoOptions :: SearchRepoOptions
+defaultSearchRepoOptions = SearchRepoOptions
+    { searchRepoOptionsKeyword  = ""
+    , searchRepoOptionsSortBy   = Nothing
+    , searchRepoOptionsOrder    = Nothing
+    , searchRepoOptionsCreated  = Nothing
+    , searchRepoOptionsPushed   = Nothing
+    , searchRepoOptionsFork     = Nothing
+    , searchRepoOptionsForks    = Nothing
+    , searchRepoOptionsIn       = Nothing
+    , searchRepoOptionsLanguage = Nothing
+    , searchRepoOptionsLicense  = Nothing
+    , searchRepoOptionsRepoUser = Nothing
+    , searchRepoOptionsSize     = Nothing
+    , searchRepoOptionsStars    = Nothing
+    , searchRepoOptionsTopic    = Nothing
+    , searchRepoOptionsArchived = Nothing
+    }
+
+-- | See <https://developer.github.com/v3/issues/#parameters-1>.
+newtype SearchRepoMod = SearchRepoMod (SearchRepoOptions -> SearchRepoOptions)
+
+instance Semigroup SearchRepoMod where
+    SearchRepoMod f <> SearchRepoMod g = SearchRepoMod (g . f)
+
+instance Monoid SearchRepoMod where
+    mempty  = SearchRepoMod id
+    mappend = (<>)
+
+toSearchRepoOptions :: SearchRepoMod -> SearchRepoOptions
+toSearchRepoOptions (SearchRepoMod f) = f defaultSearchRepoOptions
+
+searchRepoModToQueryString :: SearchRepoMod -> QueryString
+searchRepoModToQueryString = searchRepoOptionsToQueryString . toSearchRepoOptions
+
+searchRepoOptionsToQueryString :: SearchRepoOptions -> QueryString
+searchRepoOptionsToQueryString SearchRepoOptions {..} =
+    [ ("q", plussedArgs)
+    ] ++ catMaybes
+    [ mk "sort"     <$> fmap sort' searchRepoOptionsSortBy
+    , mk "order"    <$> fmap direction' searchRepoOptionsOrder
+    , mk "fork"     <$> fmap (one . T.pack . show) searchRepoOptionsFork
+    , mk "forks"    <$> fmap (one . T.pack . show) searchRepoOptionsForks
+    , mk "size"     <$> fmap (one . T.pack . show) searchRepoOptionsSize
+    , mk "stars"    <$> fmap (one . T.pack . show) searchRepoOptionsStars
+    , mk "archived" <$> fmap (one . T.pack . show) searchRepoOptionsArchived
+    ]
+  where
+    mk k v = (k, v)
+    one = (\x -> [x]) . W.QE . TE.encodeUtf8
+
+    -- example  q=tetris+language:assembly+topic:ruby
+    -- into       [QS "tetris", QPlus, QS "language", QColon, QS "assembly", QPlus, ..
+    plussedArgs = [W.QE (TE.encodeUtf8 searchRepoOptionsKeyword), W.QN "+"] ++ intercalate [W.QN "+"]
+       ( catMaybes [ ([W.QE "created",  W.QN ":"] ++) <$> created'
+                   , ([W.QE "pushed",   W.QN ":"] ++) <$> pushed'
+                   , ([W.QE "topic",    W.QN ":"] ++) <$> topic'
+                   , ([W.QE "language", W.QN ":"] ++) <$> language'
+                   , ([W.QE "license",  W.QN ":"] ++) <$> license'
+                   ])
+
+    sort' x = case x of
+        Stars   -> [W.QE "stars"]
+        Forks   -> [W.QE "forks"]
+        Updated -> [W.QE "updated"]
+
+    direction' x = case x of
+        SortDescending -> [W.QE "desc"]
+        SortAscending  -> [W.QE "asc"]
+
+    created'  = one . T.pack . (\(x,y) -> showGregorian x
+                                          ++ ".." ++
+                                          showGregorian y) <$> searchRepoOptionsCreated
+
+    pushed'   = one . T.pack . (\(x,y) -> showGregorian x
+                                          ++ ".." ++
+                                          showGregorian y) <$> searchRepoOptionsPushed
+    topic' = one . T.pack <$> searchRepoOptionsTopic
+    language' = one . (\(Language x) -> x) <$> searchRepoOptionsLanguage
+
+    -- see <https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type>
+    license' = one . (\(License x) -> x) <$> searchRepoOptionsLicense
+

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -36,6 +36,7 @@ import qualified Data.ByteString.Lazy      as LBS
 import qualified Data.Text                 as T
 import qualified Network.HTTP.Types        as Types
 import qualified Network.HTTP.Types.Method as Method
+import qualified Network.HTTP.Types        as W
 import Network.URI                         (URI)
 ------------------------------------------------------------------------------
 -- Auxillary types
@@ -240,6 +241,14 @@ instance Hashable (SimpleRequest k a) where
              `hashWithSalt` m
              `hashWithSalt` ps
              `hashWithSalt` body
+
+instance Hashable W.EscapeItem where
+    hashWithSalt salt (W.QE b) =
+        salt `hashWithSalt` (0 :: Int)
+             `hashWithSalt` b
+    hashWithSalt salt (W.QN b) =
+        salt `hashWithSalt` (1 :: Int)
+             `hashWithSalt` b
 
 instance Hashable (Request k a) where
     hashWithSalt salt (SimpleQuery req) =

--- a/src/GitHub/Endpoints/GitData/Trees.hs
+++ b/src/GitHub/Endpoints/GitData/Trees.hs
@@ -18,6 +18,7 @@ module GitHub.Endpoints.GitData.Trees (
 import GitHub.Data
 import GitHub.Internal.Prelude
 import GitHub.Request
+import qualified Network.HTTP.Types as W
 import Prelude ()
 
 -- | A tree for a SHA1.
@@ -56,4 +57,5 @@ nestedTree = nestedTree' Nothing
 -- See <https://developer.github.com/v3/git/trees/#get-a-tree-recursively>
 nestedTreeR :: Name Owner -> Name Repo -> Name Tree -> Request k Tree
 nestedTreeR user repo sha =
-    query  ["repos", toPathPart user, toPathPart repo, "git", "trees", toPathPart sha] [("recursive", Just "1")]
+    query  ["repos", toPathPart user, toPathPart repo, "git", "trees", toPathPart sha]
+           [("recursive", [W.QE "1"])]

--- a/src/GitHub/Endpoints/Organizations/Members.hs
+++ b/src/GitHub/Endpoints/Organizations/Members.hs
@@ -20,6 +20,7 @@ module GitHub.Endpoints.Organizations.Members (
 import GitHub.Data
 import GitHub.Internal.Prelude
 import GitHub.Request
+import qualified Network.HTTP.Types as W
 import Prelude ()
 
 -- | All the users who are members of the specified organization,
@@ -49,7 +50,7 @@ membersOfR organization =
 -- See <https://developer.github.com/v3/orgs/members/#members-list>
 membersOfWithR :: Name Organization -> OrgMemberFilter -> OrgMemberRole -> FetchCount -> Request k (Vector SimpleUser)
 membersOfWithR org f r =
-    pagedQuery ["orgs", toPathPart org, "members"] [("filter", Just f'), ("role", Just r')]
+    pagedQuery ["orgs", toPathPart org, "members"] [("filter", [W.QE f']), ("role", [W.QE r'])]
   where
     f' = case f of
         OrgMemberFilter2faDisabled -> "2fa_disabled"

--- a/src/GitHub/Endpoints/Organizations/Teams.hs
+++ b/src/GitHub/Endpoints/Organizations/Teams.hs
@@ -39,6 +39,7 @@ module GitHub.Endpoints.Organizations.Teams (
 import GitHub.Data
 import GitHub.Internal.Prelude
 import GitHub.Request
+import qualified Network.HTTP.Types as W
 import Prelude ()
 
 -- | List teams.  List the teams of an Owner.
@@ -133,7 +134,7 @@ deleteTeamR tid =
 -- See <https://developer.github.com/v3/orgs/teams/#list-team-members>
 listTeamMembersR :: Id Team -> TeamMemberRole -> FetchCount -> Request 'RA (Vector SimpleUser)
 listTeamMembersR tid r =
-    pagedQuery ["teams", toPathPart tid, "members"] [("role", Just r')]
+    pagedQuery ["teams", toPathPart tid, "members"] [("role", [W.QE r'])]
   where
     r' = case r of
         TeamMemberRoleAll         -> "all"

--- a/src/GitHub/Endpoints/Repos.hs
+++ b/src/GitHub/Endpoints/Repos.hs
@@ -55,14 +55,15 @@ module GitHub.Endpoints.Repos (
 import GitHub.Data
 import GitHub.Internal.Prelude
 import GitHub.Request
+import qualified Network.HTTP.Types as W
 import Prelude ()
 
 repoPublicityQueryString :: RepoPublicity -> QueryString
-repoPublicityQueryString RepoPublicityAll     = [("type", Just "all")]
-repoPublicityQueryString RepoPublicityOwner   = [("type", Just "owner")]
-repoPublicityQueryString RepoPublicityMember  = [("type", Just "member")]
-repoPublicityQueryString RepoPublicityPublic  = [("type", Just "public")]
-repoPublicityQueryString RepoPublicityPrivate = [("type", Just "private")]
+repoPublicityQueryString RepoPublicityAll     = [("type", [W.QE "all"])]
+repoPublicityQueryString RepoPublicityOwner   = [("type", [W.QE "owner"])]
+repoPublicityQueryString RepoPublicityMember  = [("type", [W.QE "member"])]
+repoPublicityQueryString RepoPublicityPublic  = [("type", [W.QE "public"])]
+repoPublicityQueryString RepoPublicityPrivate = [("type", [W.QE "private"])]
 
 -- | List your repositories.
 currentUserRepos :: Auth -> RepoPublicity -> IO (Either Error (Vector Repo))
@@ -234,7 +235,7 @@ contributorsR
 contributorsR user repo anon =
     pagedQuery ["repos", toPathPart user, toPathPart repo, "contributors"] qs
   where
-    qs | anon      = [("anon", Just "true")]
+    qs | anon      = [("anon", [W.QE "true"])]
        | otherwise = []
 
 -- | The contributors to a repo, including anonymous contributors (such as

--- a/src/GitHub/Endpoints/Repos/Commits.hs
+++ b/src/GitHub/Endpoints/Repos/Commits.hs
@@ -31,13 +31,14 @@ import Prelude ()
 import qualified Data.ByteString    as BS
 import qualified Data.Text          as T
 import qualified Data.Text.Encoding as TE
+import qualified Network.HTTP.Types as W
 
-renderCommitQueryOption :: CommitQueryOption -> (BS.ByteString, Maybe BS.ByteString)
-renderCommitQueryOption (CommitQuerySha sha)      = ("sha", Just $ TE.encodeUtf8 sha)
-renderCommitQueryOption (CommitQueryPath path)     = ("path", Just $ TE.encodeUtf8 path)
-renderCommitQueryOption (CommitQueryAuthor author) = ("author", Just $ TE.encodeUtf8 author)
-renderCommitQueryOption (CommitQuerySince date)    = ("since", Just $ TE.encodeUtf8 . T.pack $ formatISO8601 date)
-renderCommitQueryOption (CommitQueryUntil date)    = ("until", Just $ TE.encodeUtf8 . T.pack $ formatISO8601 date)
+renderCommitQueryOption :: CommitQueryOption -> (BS.ByteString, [W.EscapeItem])
+renderCommitQueryOption (CommitQuerySha sha)      = ("sha", [W.QE $ TE.encodeUtf8 sha])
+renderCommitQueryOption (CommitQueryPath path)    = ("path", [W.QE $ TE.encodeUtf8 path])
+renderCommitQueryOption (CommitQueryAuthor author) = ("author", [W.QE $ TE.encodeUtf8 author])
+renderCommitQueryOption (CommitQuerySince date) = ("since", [W.QE $ TE.encodeUtf8 . T.pack $ formatISO8601 date])
+renderCommitQueryOption (CommitQueryUntil date) = ("until", [W.QE $ TE.encodeUtf8 . T.pack $ formatISO8601 date])
 
 -- | The commit history for a repo.
 --

--- a/src/GitHub/Endpoints/Repos/Contents.hs
+++ b/src/GitHub/Endpoints/Repos/Contents.hs
@@ -35,6 +35,7 @@ module GitHub.Endpoints.Repos.Contents (
 import GitHub.Data
 import GitHub.Internal.Prelude
 import GitHub.Request
+import Network.HTTP.Types(EscapeItem(..))
 import Prelude ()
 
 import Data.Maybe (maybeToList)
@@ -64,7 +65,7 @@ contentsForR
 contentsForR user repo path ref =
     query ["repos", toPathPart user, toPathPart repo, "contents", path] qs
   where
-    qs =  maybe [] (\r -> [("ref", Just . TE.encodeUtf8 $ r)]) ref
+    qs =  maybe [] (\r -> [("ref", [QE (TE.encodeUtf8 r)] )]) ref
 
 -- | The contents of a README file in a repo, given the repo owner and name
 --

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -69,7 +69,8 @@ import Data.List                  (find)
 import Network.HTTP.Client
        (HttpException (..), Manager, RequestBody (..), Response (..),
        applyBasicAuth, getUri, httpLbs, method, newManager, redirectCount,
-       requestBody, requestHeaders, setQueryString, setRequestIgnoreStatus)
+       requestBody, requestHeaders, setQueryStringPartialEscape,
+       setRequestIgnoreStatus)
 import Network.HTTP.Client.TLS  (tlsManagerSettings)
 import Network.HTTP.Link.Parser (parseLinkHeaderBS)
 import Network.HTTP.Link.Types  (Link (..), LinkParam (..), href, linkParams)
@@ -246,7 +247,7 @@ makeHttpSimpleRequest auth r = case r of
             $ setReqHeaders
             . setCheckStatus Nothing
             . setAuthRequest auth
-            . setQueryString qs
+            . setQueryStringPartialEscape qs
             $ req
     PagedQuery paths qs _ -> do
         req <- parseUrl' $ url paths
@@ -254,7 +255,7 @@ makeHttpSimpleRequest auth r = case r of
             $ setReqHeaders
             . setCheckStatus Nothing
             . setAuthRequest auth
-            . setQueryString qs
+            . setQueryStringPartialEscape qs
             $ req
     Command m paths body -> do
         req <- parseUrl' $ url paths
@@ -297,7 +298,7 @@ makeHttpSimpleRequest auth r = case r of
 
     setAuthRequest :: Maybe Auth -> HTTP.Request -> HTTP.Request
     setAuthRequest (Just (BasicAuth user pass)) = applyBasicAuth user pass
-    setAuthRequest _                                  = id
+    setAuthRequest _                            = id
 
     getOAuthHeader :: Auth -> RequestHeaders
     getOAuthHeader (OAuth token)             = [("Authorization", "token " <> token)]


### PR DESCRIPTION
fixes #262 
http-types and http-client had to be extended for partial escape. These versions are now in stackage quite a while. I built the structure that I assumed you had in mind (SearchRepoMod), but it is very tedious and in my opinion not worth the trouble. So I used two styles in GitHub.Endpoints.Search
 - Using SearchRepoMod in: searchRepos
 - Constructing the query directly: searchCode'  [("q", [QE "language", QN ":", QE "haskell"]), ..