### PR TITLE
Make fileBlobUrl and fileRawUrl optional; Fix #339.

### DIFF
--- a/spec/GitHub/CommitsSpec.hs
+++ b/spec/GitHub/CommitsSpec.hs
@@ -5,7 +5,7 @@ module GitHub.CommitsSpec where
 import qualified GitHub
 
 import GitHub.Auth                    (Auth (..))
-import GitHub.Endpoints.Repos.Commits (Commit, commitSha, commitsFor',
+import GitHub.Endpoints.Repos.Commits (commitSha, commitsFor',
                                        commitsForR, diffR, mkCommitName)
 import GitHub.Request                 (executeRequest)
 
@@ -59,4 +59,9 @@ spec = do
 
     it "issue #155" $ withAuth $ \auth -> do
       d <- executeRequest auth $ diffR "nomeata" "codespeed" (mkCommitName "ghc") (mkCommitName "tobami:master")
+      d `shouldSatisfy` isRight
+
+    -- diff that includes a commit where a submodule is removed
+    it "issue #339" $ withAuth $ \auth -> do
+      d <- executeRequest auth $ diffR "scott-fleischman" "repo-remove-submodule" "d03c152482169d809be9b1eab71dcf64d7405f76" "42cfd732b20cd093534f246e630b309186eb485d"
       d `shouldSatisfy` isRight

--- a/spec/GitHub/RateLimitSpec.hs
+++ b/spec/GitHub/RateLimitSpec.hs
@@ -7,7 +7,6 @@ import Prelude ()
 import Prelude.Compat
 
 import Data.Either.Compat (isRight)
-import Data.Foldable      (for_)
 import Data.String        (fromString)
 import System.Environment (lookupEnv)
 import Test.Hspec         (Spec, describe, it, pendingWith, shouldSatisfy)

--- a/src/GitHub/Data/GitData.hs
+++ b/src/GitHub/Data/GitData.hs
@@ -251,9 +251,9 @@ instance FromJSON GitUser where
 
 instance FromJSON File where
     parseJSON = withObject "File" $ \o -> File
-        <$> o .: "blob_url"
+        <$> o .:? "blob_url"
         <*> o .: "status"
-        <*> o .: "raw_url"
+        <*> o .:? "raw_url"
         <*> o .: "additions"
         <*> o .: "sha"
         <*> o .: "changes"

--- a/src/GitHub/Data/GitData.hs
+++ b/src/GitHub/Data/GitData.hs
@@ -184,9 +184,9 @@ instance NFData GitUser where rnf = genericRnf
 instance Binary GitUser
 
 data File = File
-    { fileBlobUrl   :: !URL
+    { fileBlobUrl   :: !(Maybe URL)
     , fileStatus    :: !Text
-    , fileRawUrl    :: !URL
+    , fileRawUrl    :: !(Maybe URL)
     , fileAdditions :: !Int
     , fileSha       :: !Text
     , fileChanges   :: !Int


### PR DESCRIPTION
This is a breaking change to the `File` type.

These fields are null for the diff api when a commit removes a submodule.

Add test that uses the repository I created to test this issue.

Remove two redundant imports to fix warnings.
