### PR TITLE
Replace issue id with number

### DIFF
--- a/spec/GitHub/SearchSpec.hs
+++ b/spec/GitHub/SearchSpec.hs
@@ -39,14 +39,12 @@ spec = do
       V.length issues `shouldBe` 2
 
       let issue1 = issues V.! 0
-      issueId issue1 `shouldBe` mkId (Proxy :: Proxy Issue) 123898390
-      issueNumber issue1 `shouldBe` 130
+      issueNumber issue1 `shouldBe` mkId (Proxy :: Proxy Issue) 130
       issueTitle issue1 `shouldBe` "Make test runner more robust"
       issueState issue1 `shouldBe` StateClosed
 
       let issue2 = issues V.! 1
-      issueId issue2 `shouldBe` mkId (Proxy :: Proxy Issue) 119694665
-      issueNumber issue2 `shouldBe` 127
+      issueNumber issue2 `shouldBe` mkId (Proxy :: Proxy Issue) 127
       issueTitle issue2 `shouldBe` "Decouple request creation from execution"
       issueState issue2 `shouldBe` StateOpen
 
@@ -54,4 +52,4 @@ spec = do
       let query = "Decouple in:title repo:phadej/github created:<=2015-12-01"
       issues <- searchResultResults . fromRightS <$> searchIssues' (Just auth) query
       length issues `shouldBe` 1
-      issueId (V.head issues) `shouldBe` mkId (Proxy :: Proxy Issue) 119694665
+      issueNumber (V.head issues) `shouldBe` mkId (Proxy :: Proxy Issue) 127

--- a/src/GitHub/Data/Issues.hs
+++ b/src/GitHub/Data/Issues.hs
@@ -22,7 +22,7 @@ data Issue = Issue
     , issueHtmlUrl     :: !(Maybe URL)
     , issueClosedBy    :: !(Maybe SimpleUser)
     , issueLabels      :: !(Vector IssueLabel)
-    , issueNumber      :: !Int
+    , issueNumber      :: !(Id Issue)
     , issueAssignees   :: !(Vector SimpleUser)
     , issueUser        :: !SimpleUser
     , issueTitle       :: !Text
@@ -31,7 +31,6 @@ data Issue = Issue
     , issueCreatedAt   :: !UTCTime
     , issueBody        :: !(Maybe Text)
     , issueState       :: !IssueState
-    , issueId          :: !(Id Issue)
     , issueComments    :: !Int
     , issueMilestone   :: !(Maybe Milestone)
     }
@@ -198,7 +197,6 @@ instance FromJSON Issue where
         <*> o .: "created_at"
         <*> o .: "body"
         <*> o .: "state"
-        <*> o .: "id"
         <*> o .: "comments"
         <*> o .:? "milestone"
 


### PR DESCRIPTION
This is roughly a duplicate of #327.  I ran into this issue today where the _number_ of the github issue needs to be passed to `editIssueR` for example, instead of the _id_ of the issue.

Let me know if anything needs changing.  Happy to make them.