### PR TITLE
Restore LTS-12 compatibility

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -145,7 +145,7 @@ Library
 
   -- other packages
   build-depends:
-    aeson                 >=1.4.0.0   && <1.5,
+    aeson                 >=1.3.0.0   && <1.5,
     base-compat           >=0.10.4    && <0.11,
     base16-bytestring     >=0.1.1.6   && <0.2,
     binary-orphans        >=0.1.8.0   && <0.2,


### PR DESCRIPTION
It compiles, but not sure you want to maintain this upstream.

I'm happy to use a fork if not.