### PR TITLE
Extend Auth to include a Bearer token

### DIFF
--- a/src/GitHub/Auth.hs
+++ b/src/GitHub/Auth.hs
@@ -19,6 +19,7 @@ data Auth
     | EnterpriseOAuth Text    -- custom API endpoint without
                               -- trailing slash
                       Token   -- token
+    | Bearer Token -- ^ bearer token
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
 instance NFData Auth where rnf = genericRnf

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -279,6 +279,7 @@ makeHttpSimpleRequest auth r = case r of
     getOAuthHeader :: Auth -> RequestHeaders
     getOAuthHeader (OAuth token)             = [("Authorization", "token " <> token)]
     getOAuthHeader (EnterpriseOAuth _ token) = [("Authorization", "token " <> token)]
+    getOAuthHeader (Bearer token)            = [("Authorization", "Bearer " <> token)]
     getOAuthHeader _                         = []
 
 -- | Query @Link@ header with @rel=next@ from the request headers.


### PR DESCRIPTION
I've been layering the GitHub Apps preview API (https://developer.github.com/v3/apps/) on top of the existing endpoints for a project of mine, but it requires `Authorization: Bearer` tokens.

Would you consider extending the `Auth` type to include bearer tokens?

FYI: I'm adding the Checks API as well, I don't know if I should send a PR for this when I'm done as it's a developer preview?