### PR TITLE
Throw on non-200 responses.

### DIFF
--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -340,7 +340,7 @@ makeHttpRequest auth r = case r of
             $ req
   where
     parseUrl' :: MonadThrow m => Text -> m HTTP.Request
-    parseUrl' = HTTP.parseRequest . T.unpack
+    parseUrl' = HTTP.parseUrlThrow . T.unpack
 
     url :: Paths -> Text
     url paths = baseUrl <> "/" <> T.intercalate "/" paths


### PR DESCRIPTION
Replace [parseRequest](https://stackage.org/haddock/lts-13.13/http-client-0.5.14/Network-HTTP-Client.html#v:parseRequest) with [parseUrlThrow](https://stackage.org/haddock/lts-13.13/http-client-0.5.14/Network-HTTP-Client.html#v:parseUrlThrow). The latter will throw if the response is does not have a status code of `2xx`.