### PR TITLE
Authentication for GitHub Apps

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -72,6 +72,7 @@ library
     GitHub.Auth
     GitHub.Data
     GitHub.Data.Activities
+    GitHub.Data.Apps
     GitHub.Data.Comments
     GitHub.Data.Content
     GitHub.Data.Definitions
@@ -102,6 +103,7 @@ library
     GitHub.Endpoints.Activity.Events
     GitHub.Endpoints.Activity.Starring
     GitHub.Endpoints.Activity.Watching
+    GitHub.Endpoints.Apps
     GitHub.Endpoints.Gists
     GitHub.Endpoints.Gists.Comments
     GitHub.Endpoints.GitData.Blobs

--- a/src/GitHub/Auth.hs
+++ b/src/GitHub/Auth.hs
@@ -3,24 +3,66 @@
 -- License     :  BSD-3-Clause
 -- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
 --
-module GitHub.Auth where
+module GitHub.Auth (
+    Auth (..),
+    AppAuth (..),
+    AuthMethod,
+    endpoint,
+    setAuthRequest
+    ) where
 
 import GitHub.Internal.Prelude
 import Prelude ()
 
-import qualified Data.ByteString as BS
+import qualified Data.ByteString     as BS
+import qualified Network.HTTP.Client as HTTP
 
 type Token = BS.ByteString
 
 -- | The Github auth data type
 data Auth
-    = BasicAuth BS.ByteString BS.ByteString
-    | OAuth Token -- ^ token
-    | EnterpriseOAuth Text    -- custom API endpoint without
-                              -- trailing slash
-                      Token   -- token
+    = BasicAuth BS.ByteString BS.ByteString  -- ^ Username and password
+    | OAuth Token                            -- ^ OAuth token
+    | EnterpriseOAuth Text Token             -- ^ Custom endpoint and OAuth token
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
 instance NFData Auth where rnf = genericRnf
 instance Binary Auth
 instance Hashable Auth
+
+-- | The Github App auth data type
+data AppAuth
+    = JWT Token                 -- ^ JWT
+    | EnterpriseJWT Text Token  -- ^ Custom endpoint and JWT
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData AppAuth where rnf = genericRnf
+instance Binary AppAuth
+instance Hashable AppAuth
+
+-- | A type class for different authentication methods
+class AuthMethod a where
+    -- | Custom API endpoint without trailing slash
+    endpoint       :: a -> Maybe Text
+    -- | A function which sets authorisation on an HTTP request
+    setAuthRequest :: a -> HTTP.Request -> HTTP.Request
+
+instance AuthMethod Auth where
+    endpoint (BasicAuth _ _)       = Nothing
+    endpoint (OAuth _)             = Nothing
+    endpoint (EnterpriseOAuth e _) = Just e
+
+    setAuthRequest (BasicAuth u p)       = HTTP.applyBasicAuth u p
+    setAuthRequest (OAuth t)             = setAuthHeader $ "token " <> t
+    setAuthRequest (EnterpriseOAuth _ t) = setAuthHeader $ "token " <> t
+
+instance AuthMethod AppAuth where
+    endpoint (JWT _)             = Nothing
+    endpoint (EnterpriseJWT e _) = Just e
+
+    setAuthRequest (JWT t)             = setAuthHeader $ "Bearer " <> t
+    setAuthRequest (EnterpriseJWT _ t) = setAuthHeader $ "Bearer " <> t
+
+setAuthHeader :: BS.ByteString -> HTTP.Request -> HTTP.Request
+setAuthHeader auth req =
+    req { HTTP.requestHeaders = ("Authorization", auth) : HTTP.requestHeaders req }

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -35,6 +35,7 @@ module GitHub.Data (
     -- * Module re-exports
     module GitHub.Auth,
     module GitHub.Data.Activities,
+    module GitHub.Data.Apps,
     module GitHub.Data.Comments,
     module GitHub.Data.Content,
     module GitHub.Data.Definitions,
@@ -66,6 +67,7 @@ import Prelude ()
 
 import GitHub.Auth
 import GitHub.Data.Activities
+import GitHub.Data.Apps
 import GitHub.Data.Comments
 import GitHub.Data.Content
 import GitHub.Data.Definitions
@@ -125,6 +127,9 @@ mkRepoName = N
 
 mkCommitName :: Text -> Name Commit
 mkCommitName = N
+
+mkInstallationId :: Int -> Id Installation
+mkInstallationId = Id
 
 fromOrganizationName :: Name Organization -> Name Owner
 fromOrganizationName = N . untagName

--- a/src/GitHub/Data/Apps.hs
+++ b/src/GitHub/Data/Apps.hs
@@ -1,0 +1,32 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+module GitHub.Data.Apps where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+-- | Currently only used for Id Installation
+data Installation = Installation
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+-- | Response type for a new access token
+data AccessToken = AccessToken
+    { accessTokenToken      :: !Text
+    , accessTokenExpiration :: !UTCTime
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData AccessToken where rnf = genericRnf
+instance Binary AccessToken
+
+-------------------------------------------------------------------------------
+-- JSON instances
+-------------------------------------------------------------------------------
+
+instance FromJSON AccessToken where
+  parseJSON = withObject "AccessToken" $ \o -> AccessToken
+      <$> o .: "token"
+      <*> o .: "expires_at"

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -106,15 +106,16 @@ instance NFData FetchCount where rnf = genericRnf
 -------------------------------------------------------------------------------
 
 data MediaType
-    = MtJSON     -- ^ @application/vnd.github.v3+json@
-    | MtRaw      -- ^ @application/vnd.github.v3.raw@ <https://developer.github.com/v3/media/#raw-1>
-    | MtDiff     -- ^ @application/vnd.github.v3.diff@ <https://developer.github.com/v3/media/#diff>
-    | MtPatch    -- ^ @application/vnd.github.v3.patch@ <https://developer.github.com/v3/media/#patch>
-    | MtSha      -- ^ @application/vnd.github.v3.sha@ <https://developer.github.com/v3/media/#sha>
-    | MtStar     -- ^ @application/vnd.github.v3.star+json@ <https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps-1>
-    | MtRedirect -- ^ <https://developer.github.com/v3/repos/contents/#get-archive-link>
-    | MtStatus   -- ^ Parse status
-    | MtUnit     -- ^ Always succeeds
+    = MtJSON               -- ^ @application/vnd.github.v3+json@
+    | MtRaw                -- ^ @application/vnd.github.v3.raw@ <https://developer.github.com/v3/media/#raw-1>
+    | MtDiff               -- ^ @application/vnd.github.v3.diff@ <https://developer.github.com/v3/media/#diff>
+    | MtPatch              -- ^ @application/vnd.github.v3.patch@ <https://developer.github.com/v3/media/#patch>
+    | MtSha                -- ^ @application/vnd.github.v3.sha@ <https://developer.github.com/v3/media/#sha>
+    | MtStar               -- ^ @application/vnd.github.v3.star+json@ <https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps-1>
+    | MtMachineManPreview  -- ^ @application/vnd.github.machine-man-preview+json@ <https://developer.github.com/v3/previews/#integrations>
+    | MtRedirect           -- ^ <https://developer.github.com/v3/repos/contents/#get-archive-link>
+    | MtStatus             -- ^ Parse status
+    | MtUnit               -- ^ Always succeeds
   deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
 
 ------------------------------------------------------------------------------

--- a/src/GitHub/Data/Webhooks.hs
+++ b/src/GitHub/Data/Webhooks.hs
@@ -5,6 +5,7 @@
 --
 module GitHub.Data.Webhooks where
 
+import GitHub.Data.Apps        (Installation)
 import GitHub.Data.Id          (Id)
 import GitHub.Data.URL         (URL)
 import GitHub.Internal.Prelude
@@ -100,6 +101,14 @@ data EditRepoWebhook = EditRepoWebhook
 
 instance NFData EditRepoWebhook where rnf = genericRnf
 instance Binary EditRepoWebhook
+
+data AppInstallation = AppInstallation
+    { appInstallationId :: !(Id Installation)
+    }
+  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData AppInstallation where rnf = genericRnf
+instance Binary AppInstallation
 
 -- JSON instances
 
@@ -205,3 +214,7 @@ instance FromJSON PingEvent where
         <$> o .: "zen"
         <*> o .: "hook"
         <*> o .: "hook_id"
+
+instance FromJSON AppInstallation where
+    parseJSON = withObject "AppInstallation" $ \o -> AppInstallation
+        <$> o .: "id"

--- a/src/GitHub/Endpoints/Apps.hs
+++ b/src/GitHub/Endpoints/Apps.hs
@@ -1,0 +1,27 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+-- The GitHub Apps API, as described at
+-- <https://developer.github.com/v3/apps/>.
+module GitHub.Endpoints.Apps
+    ( createAccessToken
+    , createAccessTokenR
+    ) where
+
+import GitHub.Data
+import GitHub.Internal.Prelude
+import GitHub.Request
+import Prelude ()
+
+-- | Create an access token for a given installation.
+createAccessToken :: AppAuth -> Id Installation -> IO (Either Error AccessToken)
+createAccessToken auth installation =
+    executeRequest auth $ createAccessTokenR installation
+
+-- | Create an access token for a given installation.
+-- See <https://developer.github.com/v3/apps/#create-a-new-installation-token>
+createAccessTokenR :: Id Installation -> GenRequest 'MtMachineManPreview 'RW AccessToken
+createAccessTokenR installation =
+    Command Post ["app", "installations", toPathPart installation, "access_tokens"] mempty

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -215,6 +215,12 @@ instance Accept 'MtStar where
 instance FromJSON a => ParseResponse 'MtStar a where
     parseResponse _ res = Tagged (parseResponseJSON res)
 
+instance Accept 'MtMachineManPreview where
+    contentType = Tagged "application/vnd.github.machine-man-preview+json"
+
+instance FromJSON a => ParseResponse 'MtMachineManPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
 -------------------------------------------------------------------------------
 -- Raw / Diff / Patch / Sha
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This adds the ability to authenticate as a [GitHub App](https://developer.github.com/apps/) and create an access token for an installation of the app.

Authenticating as a GitHub App [uses a JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/) instead of the usual OAuth tokens. Since the JWT can't be used for authentication on normal endpoints, I've created a separate type `AppAuth` so that the function type signatures can distinguish which authentication method is required.

I'm not sure what the policy is on implementing [API previews](https://developer.github.com/v3/previews/) since the APIs aren't stable. If the `github` package is only for the stable parts of the API, I might look into implementing some of the API previews as a separate package and features moved across to `github` as they become stable. I can separate the `AuthMethod` type class changes here into a new PR as that would allow alternative auth methods such as JWTs to be implemented in a separate package.