### PR TITLE
Add ssh keys endpoint support

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -87,6 +87,7 @@ library
     GitHub.Data.Milestone
     GitHub.Data.Name
     GitHub.Data.Options
+    GitHub.Data.PublicSSHKeys
     GitHub.Data.PullRequests
     GitHub.Data.RateLimit
     GitHub.Data.Releases
@@ -135,6 +136,7 @@ library
     GitHub.Endpoints.Users
     GitHub.Endpoints.Users.Emails
     GitHub.Endpoints.Users.Followers
+    GitHub.Endpoints.Users.PublicSSHKeys
     GitHub.Internal.Prelude
     GitHub.Request
 
@@ -189,6 +191,7 @@ test-suite github-test
     GitHub.IssuesSpec
     GitHub.OrganizationsSpec
     GitHub.PullRequestReviewsSpec
+    GitHub.PublicSSHKeysSpec
     GitHub.PullRequestsSpec
     GitHub.RateLimitSpec
     GitHub.ReleasesSpec

--- a/samples/Users/PublicSSHKeys/CreatePublicSSHKey.hs
+++ b/samples/Users/PublicSSHKeys/CreatePublicSSHKey.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import qualified GitHub.Data.PublicSSHKeys as PK
+import qualified GitHub.Endpoints.Users.PublicSSHKeys as PK
+import qualified GitHub.Auth as Auth
+import Data.Text (Text)
+
+main :: IO ()
+main = do
+  let auth = Auth.OAuth "auth_token"
+  ePublicSSHKey <- PK.createUserPublicSSHKey' auth newPublicSSHKey
+  case ePublicSSHKey of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right publicSSHKey) -> putStrLn $ show publicSSHKey
+
+newPublicSSHKey :: PK.NewPublicSSHKey
+newPublicSSHKey =
+    PK.NewPublicSSHKey
+        { PK.newPublicSSHKeyKey = "test-key"
+        , PK.newPublicSSHKeyTitle = "some-name-for-your-key"
+        }

--- a/samples/Users/PublicSSHKeys/DeletePublicSSHKey.hs
+++ b/samples/Users/PublicSSHKeys/DeletePublicSSHKey.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import GitHub.Data.Id (Id (..))
+import qualified GitHub.Endpoints.Users.PublicSSHKeys as PK
+import qualified GitHub.Auth as Auth
+
+main :: IO ()
+main = do
+  let auth = Auth.OAuth "auth_token"
+  ePublicSSHKey <- PK.deleteUserPublicSSHKey' auth (Id 18530161)
+  case ePublicSSHKey of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right _) -> putStrLn $ "Deleted public SSH key!"

--- a/samples/Users/PublicSSHKeys/ListPublicSSHKeys.hs
+++ b/samples/Users/PublicSSHKeys/ListPublicSSHKeys.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import qualified GitHub.Data.PublicSSHKeys as PK
+import qualified GitHub.Endpoints.Users.PublicSSHKeys as PK
+import qualified GitHub.Auth as Auth
+import Data.List (intercalate)
+import Data.Vector (toList)
+
+main :: IO ()
+main = do
+  -- Fetch the SSH public keys of another user
+  ePublicSSHKeys <- PK.publicSSHKeysFor' "github_name"
+  case ePublicSSHKeys of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right publicSSHKeys) -> putStrLn $ intercalate "\n" $ map show (toList publicSSHKeys)
+
+  -- Fetch my SSH public keys
+  let auth = Auth.OAuth "auth_token"
+  eMyPublicSSHKeys <- PK.publicSSHKeys' auth
+  case eMyPublicSSHKeys of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right publicSSHKeys) -> putStrLn $ intercalate "\n" $ map show (toList publicSSHKeys)
+

--- a/samples/Users/PublicSSHKeys/ShowPublicSSHKey.hs
+++ b/samples/Users/PublicSSHKeys/ShowPublicSSHKey.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import GitHub.Data.Id (Id (..))
+import qualified GitHub.Data.PublicSSHKeys as PK
+import qualified GitHub.Endpoints.Users.PublicSSHKeys as PK
+import qualified GitHub.Auth as Auth
+
+main :: IO ()
+main = do
+  let auth = Auth.OAuth "auth_token"
+  ePublicSSHKey <- PK.publicSSHKey' auth (Id 18528451)
+  case ePublicSSHKey of
+    (Left err) -> putStrLn $ "Error: " ++ (show err)
+    (Right publicSSHKey) -> putStrLn $ show publicSSHKey

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -269,3 +269,56 @@ executable github-teaminfo-for
     , text
     , github-samples
   default-language: Haskell2010
+
+executable github-create-public-ssh-key
+  main-is: CreatePublicSSHKey.hs
+  hs-source-dirs:
+      Users/PublicSSHKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  default-language: Haskell2010
+
+executable github-delete-public-ssh-key
+  main-is: DeletePublicSSHKey.hs
+  hs-source-dirs:
+      Users/PublicSSHKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  default-language: Haskell2010
+
+executable github-list-public-ssh-keys
+  main-is: ListPublicSSHKeys.hs
+  hs-source-dirs:
+      Users/PublicSSHKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+    , vector
+  default-language: Haskell2010
+
+executable github-get-public-ssh-key
+  main-is: ShowPublicSSHKey.hs
+  hs-source-dirs:
+      Users/PublicSSHKeys
+  ghc-options: -Wall
+  build-depends:
+      base
+    , base-compat
+    , github
+    , text
+    , github-samples
+  default-language: Haskell2010

--- a/spec/GitHub/PublicSSHKeysSpec.hs
+++ b/spec/GitHub/PublicSSHKeysSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module GitHub.PublicSSHKeysSpec where
+
+import GitHub                 (Auth (..), PublicSSHKeyBasic (..), PublicSSHKey (..),
+                               executeRequest, repositoryR)
+import GitHub.Endpoints.Users.PublicSSHKeys (publicSSHKeysFor', publicSSHKeys',
+                               publicSSHKey')
+
+import Data.Either.Compat (isRight)
+import Data.String        (fromString)
+import System.Environment (lookupEnv)
+import Test.Hspec         (Spec, describe, it, pendingWith, shouldBe,
+                           shouldSatisfy)
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector as V
+
+fromRightS :: Show a => Either a b -> b
+fromRightS (Right b) = b
+fromRightS (Left a) = error $ "Expected a Right and got a Left" ++ show a
+
+withAuth :: (Auth -> IO ()) -> IO ()
+withAuth action = do
+  mtoken <- lookupEnv "GITHUB_TOKEN"
+  case mtoken of
+    Nothing    -> pendingWith "no GITHUB_TOKEN"
+    Just token -> action (OAuth $ fromString token)
+
+spec :: Spec
+spec = do
+  describe "publicSSHKeysFor'" $ do
+    it "works" $ do
+      keys <- publicSSHKeysFor' "phadej"
+      V.length (fromRightS keys) `shouldSatisfy` (> 1)
+
+  describe "publicSSHKeys' and publicSSHKey'" $ do
+    it "works" $ withAuth $ \auth -> do
+      keys <- publicSSHKeys' auth
+      V.length (fromRightS keys) `shouldSatisfy` (> 1)
+
+      key <- publicSSHKey' auth (publicSSHKeyId $ V.head (fromRightS keys))
+      key `shouldSatisfy` isRight

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -48,6 +48,7 @@ module GitHub.Data (
     module GitHub.Data.Issues,
     module GitHub.Data.Milestone,
     module GitHub.Data.Options,
+    module GitHub.Data.PublicSSHKeys,
     module GitHub.Data.PullRequests,
     module GitHub.Data.RateLimit,
     module GitHub.Data.Releases,
@@ -81,6 +82,7 @@ import GitHub.Data.Issues
 import GitHub.Data.Milestone
 import GitHub.Data.Name
 import GitHub.Data.Options
+import GitHub.Data.PublicSSHKeys
 import GitHub.Data.PullRequests
 import GitHub.Data.RateLimit
 import GitHub.Data.Releases

--- a/src/GitHub/Data/PublicSSHKeys.hs
+++ b/src/GitHub/Data/PublicSSHKeys.hs
@@ -27,7 +27,7 @@ data PublicSSHKey = PublicSSHKey
     , publicSSHKeyUrl       :: !URL
     , publicSSHKeyTitle     :: !Text
     , publicSSHKeyVerified  :: !Bool
-    , publicSSHKeyCreatedAt :: !UTCTime
+    , publicSSHKeyCreatedAt :: !(Maybe UTCTime)
     , publicSSHKeyReadOnly  :: !Bool
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
@@ -39,7 +39,7 @@ instance FromJSON PublicSSHKey where
         <*> o .: "url"
         <*> o .: "title"
         <*> o .: "verified"
-        <*> o .: "created_at"
+        <*> o .:? "created_at"
         <*> o .: "read_only"
 
 data NewPublicSSHKey = NewPublicSSHKey

--- a/src/GitHub/Data/PublicSSHKeys.hs
+++ b/src/GitHub/Data/PublicSSHKeys.hs
@@ -1,0 +1,60 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Todd Mohney <toddmohney@gmail.com>
+--
+module GitHub.Data.PublicSSHKeys where
+
+import GitHub.Data.Id          (Id)
+import GitHub.Data.URL         (URL)
+import GitHub.Internal.Prelude
+import Prelude ()
+
+data PublicSSHKeyBasic = PublicSSHKeyBasic
+    { basicPublicSSHKeyId        :: !(Id PublicSSHKey)
+    , basicPublicSSHKeyKey       :: !Text
+    }
+  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance FromJSON PublicSSHKeyBasic where
+    parseJSON = withObject "PublicSSHKeyBasic" $ \o -> PublicSSHKeyBasic
+        <$> o .: "id"
+        <*> o .: "key"
+
+data PublicSSHKey = PublicSSHKey
+    { publicSSHKeyId        :: !(Id PublicSSHKey)
+    , publicSSHKeyKey       :: !Text
+    , publicSSHKeyUrl       :: !URL
+    , publicSSHKeyTitle     :: !Text
+    , publicSSHKeyVerified  :: !Bool
+    , publicSSHKeyCreatedAt :: !UTCTime
+    , publicSSHKeyReadOnly  :: !Bool
+    }
+  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance FromJSON PublicSSHKey where
+    parseJSON = withObject "PublicSSHKey" $ \o -> PublicSSHKey
+        <$> o .: "id"
+        <*> o .: "key"
+        <*> o .: "url"
+        <*> o .: "title"
+        <*> o .: "verified"
+        <*> o .: "created_at"
+        <*> o .: "read_only"
+
+data NewPublicSSHKey = NewPublicSSHKey
+    { newPublicSSHKeyKey      :: !Text
+    , newPublicSSHKeyTitle    :: !Text
+    }
+  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance ToJSON NewPublicSSHKey where
+    toJSON (NewPublicSSHKey key title) = object
+        [ "key" .= key
+        , "title" .= title
+        ]
+
+instance FromJSON NewPublicSSHKey where
+    parseJSON = withObject "PublicSSHKey" $ \o -> NewPublicSSHKey
+        <$> o .: "key"
+        <*> o .: "title"

--- a/src/GitHub/Endpoints/Users/PublicSSHKeys.hs
+++ b/src/GitHub/Endpoints/Users/PublicSSHKeys.hs
@@ -1,0 +1,83 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Todd Mohney <toddmohney@gmail.com>
+--
+-- The public keys API, as described at
+-- <https://developer.github.com/v3/users/keys/>
+module GitHub.Endpoints.Users.PublicSSHKeys (
+    -- * Querying public SSH keys
+    publicSSHKeys',
+    publicSSHKeysR,
+    publicSSHKeysFor',
+    publicSSHKeysForR,
+    publicSSHKey',
+    publicSSHKeyR,
+
+    -- ** Create
+    createUserPublicSSHKey',
+    createUserPublicSSHKeyR,
+
+    -- ** Delete
+    deleteUserPublicSSHKey',
+    deleteUserPublicSSHKeyR,
+) where
+
+import GitHub.Data
+import GitHub.Internal.Prelude
+import GitHub.Request
+import Prelude ()
+
+-- | Querying public SSH keys.
+publicSSHKeysFor' :: Name Owner -> IO (Either Error (Vector PublicSSHKeyBasic))
+publicSSHKeysFor' user =
+    executeRequest' $ publicSSHKeysForR user FetchAll
+
+-- | Querying public SSH keys.
+-- See <https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user>
+publicSSHKeysForR :: Name Owner -> FetchCount -> Request 'RO (Vector PublicSSHKeyBasic)
+publicSSHKeysForR user =
+    pagedQuery ["users", toPathPart user, "keys"] []
+
+-- | Querying the authenticated users' public SSH keys
+publicSSHKeys' :: Auth -> IO (Either Error (Vector PublicSSHKey))
+publicSSHKeys' auth =
+    executeRequest auth publicSSHKeysR
+
+-- | Querying the authenticated users' public SSH keys
+-- See <https://developer.github.com/v3/users/keys/#list-your-public-keys>
+publicSSHKeysR :: Request 'RA (Vector PublicSSHKey)
+publicSSHKeysR =
+    query ["user", "keys"] []
+
+-- | Querying a public SSH key
+publicSSHKey' :: Auth -> Id PublicSSHKey -> IO (Either Error PublicSSHKey)
+publicSSHKey' auth keyId =
+    executeRequest auth $ publicSSHKeyR keyId
+
+-- | Querying a public SSH key.
+-- See <https://developer.github.com/v3/users/keys/#get-a-single-public-key>
+publicSSHKeyR :: Id PublicSSHKey -> Request 'RA PublicSSHKey
+publicSSHKeyR keyId =
+    query ["user", "keys", toPathPart keyId] []
+
+-- | Create a public SSH key
+createUserPublicSSHKey' :: Auth -> NewPublicSSHKey -> IO (Either Error PublicSSHKey)
+createUserPublicSSHKey' auth key =
+    executeRequest auth $ createUserPublicSSHKeyR key
+
+-- | Create a public SSH key.
+-- See <https://developer.github.com/v3/users/keys/#create-a-public-key>.
+createUserPublicSSHKeyR :: NewPublicSSHKey -> Request 'RW PublicSSHKey
+createUserPublicSSHKeyR key =
+    command Post ["user", "keys"] (encode key)
+
+deleteUserPublicSSHKey' :: Auth -> Id PublicSSHKey -> IO (Either Error ())
+deleteUserPublicSSHKey' auth keyId =
+    executeRequest auth $ deleteUserPublicSSHKeyR keyId
+
+-- | Delete a public SSH key.
+-- See <https://developer.github.com/v3/users/keys/#delete-a-public-key>
+deleteUserPublicSSHKeyR :: Id PublicSSHKey -> Request 'RW ()
+deleteUserPublicSSHKeyR keyId =
+    command Delete ["user", "keys", toPathPart keyId] mempty


### PR DESCRIPTION
[Resolves phadej/github#362]

- Implements an interface for GitHub's SSH public key API
- Adds tests for the read-only interface
- Does _not_ add tests for SSH key creation/deletion to avoid polluting anyone's GH account
- Adds relevant samples