### PR TITLE
Tested with semigroups 0.19.

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -166,7 +166,7 @@ library
     , http-types            >=0.12.1     && <0.13
     , iso8601-time          >=0.1.5      && <0.2
     , network-uri           >=2.6.1.0    && <2.7
-    , semigroups            >=0.18.5     && <0.19
+    , semigroups            >=0.18.5     && <0.20
     , tagged
     , tls                   >=1.4.1
     , transformers-compat   >=0.6        && <0.7


### PR DESCRIPTION
I hadn't any problem installing the library using [semigroups-0.19](http://hackage.haskell.org/package/semigroups-0.19), so I bumped the upper bound.

Could you also bump the upper bound in Hackage, please.