### PR TITLE
Media types for GitHub API previews

### DIFF
--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -106,6 +106,7 @@ instance NFData FetchCount where rnf = genericRnf
 -------------------------------------------------------------------------------
 
 data MediaType
+    -- Standard media types
     = MtJSON     -- ^ @application/vnd.github.v3+json@
     | MtRaw      -- ^ @application/vnd.github.v3.raw@ <https://developer.github.com/v3/media/#raw-1>
     | MtDiff     -- ^ @application/vnd.github.v3.diff@ <https://developer.github.com/v3/media/#diff>
@@ -115,6 +116,41 @@ data MediaType
     | MtRedirect -- ^ <https://developer.github.com/v3/repos/contents/#get-archive-link>
     | MtStatus   -- ^ Parse status
     | MtUnit     -- ^ Always succeeds
+    -- Media types for GitHub API previews
+    | MtWyandottePreview       -- ^ @application/vnd.github.wyandotte-preview+json@ <https://developer.github.com/v3/previews/#migrations>
+    | MtBarredRockPreview      -- ^ @application/vnd.github.barred-rock-preview+json@ <https://developer.github.com/v3/previews/#source-import>
+    | MtAntManPreview          -- ^ @application/vnd.github.ant-man-preview+json@ <https://developer.github.com/v3/previews/#enhanced-deployments>
+    | MtSquirrelGirlPreview    -- ^ @application/vnd.github.squirrel-girl-preview+json@ <https://developer.github.com/v3/previews/#reactions>
+    | MtMockingbirdPreview     -- ^ @application/vnd.github.mockingbird-preview+json@ <https://developer.github.com/v3/previews/#timeline>
+    | MtMisterFantasticPreview -- ^ @application/vnd.github.mister-fantastic-preview+json@ <https://developer.github.com/v3/previews/#pages>
+    | MtMachineManPreview      -- ^ @application/vnd.github.machine-man-preview+json@ <https://developer.github.com/v3/previews/#integrations>
+    | MtInertiaPreview         -- ^ @application/vnd.github.inertia-preview+json@ <https://developer.github.com/v3/previews/#projects>
+    | MtCloakPreview           -- ^ @application/vnd.github.cloak-preview+json@ <https://developer.github.com/v3/previews/#commit-search>
+    | MtBlackPantherPreview    -- ^ @application/vnd.github.black-panther-preview+json@ <https://developer.github.com/v3/previews/#community-profile-metrics>
+    | MtGiantSentryFistPreview -- ^ @application/vnd.github.giant-sentry-fist-preview+json@ <https://developer.github.com/v3/previews/#user-blocking>
+    | MtMercyPreview           -- ^ @application/vnd.github.mercy-preview+json@ <https://developer.github.com/v3/previews/#repository-topics>
+    | MtScarletWitchPreview    -- ^ @application/vnd.github.scarlet-witch-preview+json@ <https://developer.github.com/v3/previews/#codes-of-conduct>
+    | MtHellcatPreview         -- ^ @application/vnd.github.hellcat-preview+json@ <https://developer.github.com/v3/previews/#nested-teams>
+    | MtNightshadePreview      -- ^ @application/vnd.github.nightshade-preview+json@ <https://developer.github.com/v3/previews/#repository-transfer>
+    | MtSailorVPreview         -- ^ @application/vnd.github.sailor-v-preview+json@ <https://developer.github.com/v3/previews/#add-lock-reason>
+    | MtDazzlerPreview         -- ^ @application/vnd.github.dazzler-preview+json@ <https://developer.github.com/v3/previews/#organization-invitations>
+    | MtEchoPreview            -- ^ @application/vnd.github.echo-preview+json@ <https://developer.github.com/v3/previews/#team-discussions>
+    | MtSymmetraPreview        -- ^ @application/vnd.github.symmetra-preview+json@ <https://developer.github.com/v3/previews/#label-emoji-search-and-descriptions>
+    | MtZzzaxPreview           -- ^ @application/vnd.github.zzzax-preview+json@ <https://developer.github.com/v3/previews/#require-signed-commits>
+    | MtLukeCagePreview        -- ^ @application/vnd.github.luke-cage-preview+json@ <https://developer.github.com/v3/previews/#require-multiple-approving-reviews>
+    | MtHagarPreview           -- ^ @application/vnd.github.hagar-preview+json@ <https://developer.github.com/v3/previews/#retrieve-hovercard-information>
+    | MtAntiopePreview         -- ^ @application/vnd.github.antiope-preview+json@ <https://developer.github.com/v3/previews/#check-runs-and-check-suites-api>
+    | MtStarfoxPreview         -- ^ @application/vnd.github.starfox-preview+json@ <https://developer.github.com/v3/previews/#project-card-details>
+    | MtFuryPreview            -- ^ @application/vnd.github.fury-preview+json@ <https://developer.github.com/v3/previews/#github-app-manifests>
+    | MtFlashPreview           -- ^ @application/vnd.github.flash-preview+json@ <https://developer.github.com/v3/previews/#deployment-statuses>
+    | MtSurturPreview          -- ^ @application/vnd.github.surtur-preview+json@ <https://developer.github.com/v3/previews/#repository-creation-permissions>
+    | MtCorsairPreview         -- ^ @application/vnd.github.corsair-preview+json@ <https://developer.github.com/v3/previews/#content-attachments>
+    | MtSombraPreview          -- ^ @application/vnd.github.sombra-preview+json@ <https://developer.github.com/v3/previews/#interaction-restrictions-for-repositories-and-organizations>
+    | MtShadowCatPreview       -- ^ @application/vnd.github.shadow-cat-preview+json@ <https://developer.github.com/v3/previews/#draft-pull-requests>
+    | MtSwitcherooPreview      -- ^ @application/vnd.github.switcheroo-preview+json@ <https://developer.github.com/v3/previews/#enable-and-disable-pages>
+    | MtGrootPreview           -- ^ @application/vnd.github.groot-preview+json@ <https://developer.github.com/v3/previews/#list-branches-or-pull-requests-for-a-commit>
+    | MtGambitPreview          -- ^ @application/vnd.github.gambit-preview+json@ <https://developer.github.com/v3/previews/#uninstall-a-github-app>
+    | MtDorianPreview          -- ^ @application/vnd.github.dorian-preview+json@ <https://developer.github.com/v3/previews/#enable-or-disable-vulnerability-alerts-for-a-repository>
   deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
 
 ------------------------------------------------------------------------------

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -182,7 +182,7 @@ class Accept mt => ParseResponse (mt :: MediaType) a where
     parseResponse :: MonadError Error m => HTTP.Request -> HTTP.Response LBS.ByteString -> Tagged mt (m a)
 
 -------------------------------------------------------------------------------
--- JSON (+ star)
+-- JSON instances
 -------------------------------------------------------------------------------
 
 -- | Parse API response.
@@ -205,6 +205,210 @@ instance Accept 'MtStar where
     contentType = Tagged "application/vnd.github.v3.star+json"
 
 instance FromJSON a => ParseResponse 'MtStar a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtWyandottePreview where
+    contentType = Tagged "application/vnd.github.wyandotte-preview+json"
+
+instance FromJSON a => ParseResponse 'MtWyandottePreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtBarredRockPreview where
+    contentType = Tagged "application/vnd.github.barred-rock-preview+json"
+
+instance FromJSON a => ParseResponse 'MtBarredRockPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtAntManPreview where
+    contentType = Tagged "application/vnd.github.ant-man-preview+json"
+
+instance FromJSON a => ParseResponse 'MtAntManPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtSquirrelGirlPreview where
+    contentType = Tagged "application/vnd.github.squirrel-girl-preview+json"
+
+instance FromJSON a => ParseResponse 'MtSquirrelGirlPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtMockingbirdPreview where
+    contentType = Tagged "application/vnd.github.mockingbird-preview+json"
+
+instance FromJSON a => ParseResponse 'MtMockingbirdPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtMisterFantasticPreview where
+    contentType = Tagged "application/vnd.github.mister-fantastic-preview+json"
+
+instance FromJSON a => ParseResponse 'MtMisterFantasticPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtMachineManPreview where
+    contentType = Tagged "application/vnd.github.machine-man-preview+json"
+
+instance FromJSON a => ParseResponse 'MtMachineManPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtInertiaPreview where
+    contentType = Tagged "application/vnd.github.inertia-preview+json"
+
+instance FromJSON a => ParseResponse 'MtInertiaPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtCloakPreview where
+    contentType = Tagged "application/vnd.github.cloak-preview+json"
+
+instance FromJSON a => ParseResponse 'MtCloakPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtBlackPantherPreview where
+    contentType = Tagged "application/vnd.github.black-panther-preview+json"
+
+instance FromJSON a => ParseResponse 'MtBlackPantherPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtGiantSentryFistPreview where
+    contentType = Tagged "application/vnd.github.giant-sentry-fist-preview+json"
+
+instance FromJSON a => ParseResponse 'MtGiantSentryFistPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtMercyPreview where
+    contentType = Tagged "application/vnd.github.mercy-preview+json"
+
+instance FromJSON a => ParseResponse 'MtMercyPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtScarletWitchPreview where
+    contentType = Tagged "application/vnd.github.scarlet-witch-preview+json"
+
+instance FromJSON a => ParseResponse 'MtScarletWitchPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtHellcatPreview where
+    contentType = Tagged "application/vnd.github.hellcat-preview+json"
+
+instance FromJSON a => ParseResponse 'MtHellcatPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtNightshadePreview where
+    contentType = Tagged "application/vnd.github.nightshade-preview+json"
+
+instance FromJSON a => ParseResponse 'MtNightshadePreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtSailorVPreview where
+    contentType = Tagged "application/vnd.github.sailor-v-preview+json"
+
+instance FromJSON a => ParseResponse 'MtSailorVPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtDazzlerPreview where
+    contentType = Tagged "application/vnd.github.dazzler-preview+json"
+
+instance FromJSON a => ParseResponse 'MtDazzlerPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtEchoPreview where
+    contentType = Tagged "application/vnd.github.echo-preview+json"
+
+instance FromJSON a => ParseResponse 'MtEchoPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtSymmetraPreview where
+    contentType = Tagged "application/vnd.github.symmetra-preview+json"
+
+instance FromJSON a => ParseResponse 'MtSymmetraPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtZzzaxPreview where
+    contentType = Tagged "application/vnd.github.zzzax-preview+json"
+
+instance FromJSON a => ParseResponse 'MtZzzaxPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtLukeCagePreview where
+    contentType = Tagged "application/vnd.github.luke-cage-preview+json"
+
+instance FromJSON a => ParseResponse 'MtLukeCagePreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtHagarPreview where
+    contentType = Tagged "application/vnd.github.hagar-preview+json"
+
+instance FromJSON a => ParseResponse 'MtHagarPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtAntiopePreview where
+    contentType = Tagged "application/vnd.github.antiope-preview+json"
+
+instance FromJSON a => ParseResponse 'MtAntiopePreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtStarfoxPreview where
+    contentType = Tagged "application/vnd.github.starfox-preview+json"
+
+instance FromJSON a => ParseResponse 'MtStarfoxPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtFuryPreview where
+    contentType = Tagged "application/vnd.github.fury-preview+json"
+
+instance FromJSON a => ParseResponse 'MtFuryPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtFlashPreview where
+    contentType = Tagged "application/vnd.github.flash-preview+json"
+
+instance FromJSON a => ParseResponse 'MtFlashPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtSurturPreview where
+    contentType = Tagged "application/vnd.github.surtur-preview+json"
+
+instance FromJSON a => ParseResponse 'MtSurturPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtCorsairPreview where
+    contentType = Tagged "application/vnd.github.corsair-preview+json"
+
+instance FromJSON a => ParseResponse 'MtCorsairPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtSombraPreview where
+    contentType = Tagged "application/vnd.github.sombra-preview+json"
+
+instance FromJSON a => ParseResponse 'MtSombraPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtShadowCatPreview where
+    contentType = Tagged "application/vnd.github.shadow-cat-preview+json"
+
+instance FromJSON a => ParseResponse 'MtShadowCatPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtSwitcherooPreview where
+    contentType = Tagged "application/vnd.github.switcheroo-preview+json"
+
+instance FromJSON a => ParseResponse 'MtSwitcherooPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtGrootPreview where
+    contentType = Tagged "application/vnd.github.groot-preview+json"
+
+instance FromJSON a => ParseResponse 'MtGrootPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtGambitPreview where
+    contentType = Tagged "application/vnd.github.gambit-preview+json"
+
+instance FromJSON a => ParseResponse 'MtGambitPreview a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
+instance Accept 'MtDorianPreview where
+    contentType = Tagged "application/vnd.github.dorian-preview+json"
+
+instance FromJSON a => ParseResponse 'MtDorianPreview a where
     parseResponse _ res = Tagged (parseResponseJSON res)
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Adds support for the media types used by [API previews](https://developer.github.com/v3/previews/). This will allow users of this library to use the existing [`GenRequest`](http://hackage.haskell.org/package/github-0.21/docs/GitHub-Request.html#t:GenRequest) type and its constructors when writing functions that use endpoints from API previews.