### PR TITLE
Add filters for all and closed PRs

### DIFF
--- a/src/GitHub/Data/Options.hs
+++ b/src/GitHub/Data/Options.hs
@@ -21,6 +21,8 @@ module GitHub.Data.Options (
     optionsNoBase,
     optionsHead,
     optionsNoHead,
+    filterAll,
+    filterClosed,
     sortByPopularity,
     sortByLongRunning,
     -- * Issues
@@ -335,6 +337,14 @@ optionsHead x = PRMod $ \opts ->
 optionsNoHead :: PullRequestMod
 optionsNoHead = PRMod $ \opts ->
     opts { pullRequestOptionsHead = Nothing }
+
+filterAll :: PullRequestMod
+filterAll = PRMod $ \opts ->
+    opts { pullRequestOptionsState = Nothing }
+
+filterClosed :: PullRequestMod
+filterClosed = PRMod $ \opts ->
+    opts { pullRequestOptionsState = Just StateClosed }
 
 sortByPopularity :: PullRequestMod
 sortByPopularity = PRMod $ \opts ->


### PR DESCRIPTION
By default only "open" Pull Requests are fetched, with no way to change that (as the constructors of the type are not exported), so this adds some functions to do it.

I'm not sure I'm using the right naming convention for them though, so suggestions welcome