### PR TITLE
Bind "delete thread subscription" notification endpoint

### DIFF
--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -25,6 +25,7 @@ module GitHub (
     getNotificationsR,
     markNotificationAsReadR,
     markAllNotificationsAsReadR,
+    deleteThreadSubscriptionR,
 
     -- ** Starring
     -- | See <https://developer.github.com/v3/activity/starring/>

--- a/src/GitHub/Endpoints/Activity/Notifications.hs
+++ b/src/GitHub/Endpoints/Activity/Notifications.hs
@@ -43,3 +43,15 @@ markNotificationsAsRead auth =
 markAllNotificationsAsReadR :: GenRequest 'MtUnit 'RW ()
 markAllNotificationsAsReadR =
     Command Put ["notifications"] $ encode emptyObject
+
+deleteThreadSubscription :: Auth -> Id Notification -> IO (Either Error ())
+deleteThreadSubscription auth nid =
+    executeRequest auth $ deleteThreadSubscriptionR nid
+
+-- | Delete a thread subscription.
+-- See <https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription>
+deleteThreadSubscriptionR :: Id Notification -> GenRequest 'MtUnit 'RW ()
+deleteThreadSubscriptionR nid = Command
+    Delete
+    ["notifications", "threads", toPathPart nid, "subscription"]
+    mempty


### PR DESCRIPTION
This is used to "mute" a thread of notifications.