### PR TITLE
Alternative nix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,5 +8,8 @@ tests: True
 constraints: hashable ^>=1.3
 constraints: semigroups ^>=0.19
 
+allow-newer: aeson-1.4.2.0:hashable
+allow-newer: aeson-1.4.2.0:semigroups
+
 allow-newer: aeson-1.4.3.0:hashable
 allow-newer: aeson-1.4.3.0:semigroups

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,19 @@
 { nixpkgs ? import ./nix/nixpkgs.nix
-, dev ? false
+, cabal-v2 ? true
 }:
 let
   pkgs = import nixpkgs {};
+
+  # Newer versions to meet `constraints` in `cabal.project` for v2 builds
+  v2-overrides = super: if cabal-v2 then
+    {
+      hashable = super.hashable_1_3_0_0;
+      semigroups = super.semigroups_0_19;
+    }
+    else
+    {
+    };
+
   hp = pkgs.haskellPackages.override (with pkgs.haskell.lib; {
     overrides = self: super: {
       # Newer versions of things we need
@@ -29,7 +40,7 @@ let
       # Break infinite recursion through QuickCheck test dep
       splitmix = dontCheck super.splitmix;
 
-    };
+    } // (v2-overrides super);
   });
   github = hp.callCabal2nix "github" ./. {};
 in

--- a/default.nix
+++ b/default.nix
@@ -1,26 +1,16 @@
-{ mkDerivation, aeson, attoparsec, base, base16-bytestring
-, byteable, bytestring, case-insensitive, conduit, containers
-, cryptohash, data-default, failure, hashable, hspec, HTTP
-, http-conduit, http-types, network, old-locale, stdenv, text, time
-, unordered-containers, vector
+{ nixpkgs ? import ./nix/nixpkgs.nix
+, dev ? false
 }:
-mkDerivation {
-  pname = "github";
-  version = "0.14.0";
-  src = ./.;
-  buildDepends = [
-    aeson attoparsec base base16-bytestring byteable bytestring
-    case-insensitive conduit containers cryptohash data-default failure
-    hashable HTTP http-conduit http-types network old-locale text time
-    unordered-containers vector
-  ];
-  testDepends = [
-    aeson attoparsec base base16-bytestring byteable bytestring
-    case-insensitive conduit containers cryptohash data-default failure
-    hashable hspec HTTP http-conduit http-types network old-locale text
-    time unordered-containers vector
-  ];
-  homepage = "https://github.com/fpco/github";
-  description = "Access to the Github API, v3";
-  license = stdenv.lib.licenses.bsd3;
-}
+let
+  pkgs = import nixpkgs { config.allowBroken = true; };
+  hp = pkgs.haskellPackages.override (old: {
+    overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (self: super: with pkgs.haskell.lib; {
+      binary-instances-1 = doJailbreak self.binary-instances-1;
+      QuickCheck = self.QuickCheck_2_13_1;
+      quickcheck-instances = super.quickcheck-instances_0_3_21;
+      binary-orphans = self.binary-orphans_1_0_1;
+      github = super.callCabal2nix "github" ./github.cabal {};
+    });
+  });
+in
+  hp.github

--- a/default.nix
+++ b/default.nix
@@ -2,15 +2,35 @@
 , dev ? false
 }:
 let
-  pkgs = import nixpkgs { config.allowBroken = true; };
-  hp = pkgs.haskellPackages.override (old: {
-    overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (self: super: with pkgs.haskell.lib; {
-      binary-instances-1 = doJailbreak self.binary-instances-1;
-      QuickCheck = self.QuickCheck_2_13_1;
+  pkgs = import nixpkgs {};
+  hp = pkgs.haskellPackages.override (with pkgs.haskell.lib; {
+    overrides = self: super: {
+      # Newer versions of things we need
+      ansi-terminal = super.ansi-terminal_0_9_1;
+      binary-orphans = super.binary-orphans_1_0_1;
+      QuickCheck = super.QuickCheck_2_13_1;
       quickcheck-instances = super.quickcheck-instances_0_3_21;
-      binary-orphans = self.binary-orphans_1_0_1;
-      github = super.callCabal2nix "github" ./github.cabal {};
-    });
+      tasty = super.tasty_1_2_2;
+      time-compat = super.time-compat_1_9_2_2;
+      unordered-containers = super.unordered-containers_0_2_10_0;
+
+      # Things that work with our newer versions but don't know it yet
+      # hspec test failure looks like it relies on some RNG to be just
+      # right, not critical
+      ChasingBottoms = doJailbreak super.ChasingBottoms;
+      hspec-core = dontCheck (doJailbreak super.hspec-core);
+      optparse-applicative = doJailbreak super.optparse-applicative;
+
+      # We subbed in the correct versions of things it needs to work
+      binary-instances = overrideCabal super.binary-instances (drv: {
+        broken = false;
+      });
+
+      # Break infinite recursion through QuickCheck test dep
+      splitmix = dontCheck super.splitmix;
+
+    };
   });
+  github = hp.callCabal2nix "github" ./. {};
 in
-  hp.github
+  github

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,7 @@
+builtins.fetchGit {
+  # Descriptive name to make the store path easier to identify
+  name = "nixos-unstable-2019-05-30";
+  url = https://github.com/nixos/nixpkgs/;
+  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
+  rev = "eccb90a2d997d65dc514253b441e515d8e0241c3";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,5 @@
-{nixpkgs ? import ./nix/nixpkgs.nix}:
+{ nixpkgs ? import ./nix/nixpkgs.nix
+, cabal-v2 ? true
+}:
 
-(import ./. {inherit nixpkgs;}).env
+(import ./. {inherit nixpkgs cabal-v2;}).env

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,3 @@
 {nixpkgs ? import ./nix/nixpkgs.nix}:
 
 (import ./. {inherit nixpkgs;}).env
-# let
-#   pkgs = import nixpkgs {};
-#   ghcWithP = pkgs.haskellPackages.ghcWithPackages (hp: with hp; [
-#     pkgs.cabal-install
-#     ghcid
-#     zlib
-#   ]);
-# in
-#   pkgs.mkShell {
-#     buildInputs = [ghcWithP];
-#   }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{nixpkgs ? import ./nix/nixpkgs.nix}:
+
+(import ./. {inherit nixpkgs;}).env
+# let
+#   pkgs = import nixpkgs {};
+#   ghcWithP = pkgs.haskellPackages.ghcWithPackages (hp: with hp; [
+#     pkgs.cabal-install
+#     ghcid
+#     zlib
+#   ]);
+# in
+#   pkgs.mkShell {
+#     buildInputs = [ghcWithP];
+#   }


### PR DESCRIPTION
While I was working on #380 I (with the help of some team mates) updated the nix setup. @IvanMalison updated the nix setup before I cleaned up my changes and put them in a PR. I thought I should still raise this version, as it takes a different approach that may be preferable.

The key difference here is that `nixpkgs` is (by default) pinned to a specific commit, such that this setup should always work regardless of the user's `NIX_PATH` (where `<nixpkgs>` comes from).

I've tested this with both `nix-build` and `nix-shell --run "cabal v2-build github"`.