### PR TITLE
Pin nixpkgs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,9 @@ tests: True
 constraints: hashable ^>=1.3
 constraints: semigroups ^>=0.19
 
+allow-newer: aeson-1.4.2.0:hashable
+allow-newer: aeson-1.4.2.0:semigroups
+
 allow-newer: aeson-1.4.3.0:hashable
 allow-newer: aeson-1.4.3.0:semigroups
 

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
+{ nixpkgs ? import ./nixpkgs.nix }:
 let
-  pkgs = import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; };
+  pkgs = import nixpkgs { overlays = [ (import ./overlay.nix) ]; };
 in pkgs.haskellPackages.callCabal2nix "github" ./. { }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,14 @@
 { nixpkgs ? import ./nixpkgs.nix }:
 let
   pkgs = import nixpkgs { overlays = [ (import ./overlay.nix) ]; };
-in pkgs.haskellPackages.callCabal2nix "github" ./. { }
+  github = pkgs.haskellPackages.callCabal2nix "github" ./. { };
+  githubOpenSSL = pkgs.haskell.lib.overrideCabal github (drv: {
+    libraryHaskellDepends = drv.libraryHaskellDepends ++ (with pkgs.haskellPackages; [
+      # These are behind a flag that that is enabled in the `cabal.project` file.
+      http-client-openssl
+      HsOpenSSL
+      HsOpenSSL-x509-system
+    ]);
+  });
+in
+  githubOpenSSL

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,7 @@
+builtins.fetchGit {
+  # Descriptive name to make the store path easier to identify
+  name = "nixos-unstable-2019-05-30";
+  url = https://github.com/nixos/nixpkgs/;
+  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
+  rev = "eccb90a2d997d65dc514253b441e515d8e0241c3";
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -8,13 +8,13 @@ _: pkgs: {
       });
 
       # Newer versions of things.
-      # -------------------------
       ansi-terminal = super.ansi-terminal_0_9_1;
       binary-orphans = super.binary-orphans_1_0_1;
-      # hashable is here because it's constrained in the cabal.project file.
+      # hashable is here because of the constraint in the cabal.project file.
       hashable = super.hashable_1_3_0_0;
       QuickCheck = super.QuickCheck_2_13_1;
       quickcheck-instances = super.quickcheck-instances_0_3_21;
+      # semigroups is here because of the constraint in the cabal.project file.
       semigroups = super.semigroups_0_19;
       tasty = super.tasty_1_2_2;
       time-compat = super.time-compat_1_9_2_2;

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,31 +1,32 @@
 _: pkgs: {
   haskellPackages = pkgs.haskellPackages.override (old: {
-    overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (self: super: {
-      unordered-containers = pkgs.haskell.lib.overrideCabal super.unordered-containers (_: {
-        version = "0.2.10.0";
-        sha256 = "0wy5hfrs880hh8hvp648bl07ws777n3kkmczzdszr7papnyigwb5";
-      });
-      binary-instances = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.overrideCabal super.binary-instances (old: {
-        libraryHaskellDepends = old.libraryHaskellDepends ++ [
-          self.binary-orphans_1_0_1
-        ];
+    overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (self: super: with pkgs.haskell.lib; {
+
+      # binary-instances gets the versions it needs thanks to this overlay, so is no longer broken.
+      binary-instances = overrideCabal super.binary-instances (drv: {
         broken = false;
-      }));
-      binary-orphans_1_0_1 = pkgs.haskell.lib.dontCheck super.binary-orphans_1_0_1;
-      github = pkgs.haskell.lib.overrideCabal super.github (old: {
-        version = "0.22";
-        sha256 = "15py79qcpj0k331i42njgwkirwyiacbc5razmxnm4672dvvip2qk";
-        libraryHaskellDepends = old.libraryHaskellDepends ++ [
-          self.binary-instances self.exceptions self.transformers-compat
-        ];
       });
-      time-compat = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.overrideCabal super.time-compat (old: {
-        version = "1.9.2.2";
-        sha256 = "05va0rqs759vbridbcl6hksp967j9anjvys8vx72fnfkhlrn2s52";
-        libraryHaskellDepends = old.libraryHaskellDepends ++ [
-          self.base-orphans
-        ];
-      }));
+
+      # Newer versions of things.
+      # -------------------------
+      ansi-terminal = super.ansi-terminal_0_9_1;
+      binary-orphans = super.binary-orphans_1_0_1;
+      # hashable is here because it's constrained in the cabal.project file.
+      hashable = super.hashable_1_3_0_0;
+      QuickCheck = super.QuickCheck_2_13_1;
+      quickcheck-instances = super.quickcheck-instances_0_3_21;
+      semigroups = super.semigroups_0_19;
+      tasty = super.tasty_1_2_2;
+      time-compat = super.time-compat_1_9_2_2;
+      unordered-containers = super.unordered-containers_0_2_10_0;
+
+      # Things that work with newer versions of dependencies but don't know it yet.
+      ChasingBottoms = doJailbreak super.ChasingBottoms;
+      hspec-core = dontCheck (doJailbreak super.hspec-core);
+      optparse-applicative = doJailbreak super.optparse-applicative;
+
+      # Break infinite recursion through QuickCheck test dep
+      splitmix = dontCheck super.splitmix;
     });
   });
 }


### PR DESCRIPTION
- Pin `nixpkgs` in `default.nix` --- can be overridden by passing argument.
- Update `overlay.nix` to work with pinned version.
- Relax upper bounds for `aeson-1.4.2.0` to work with newer versions in pin.
- Add dependencies to `github`'s derivation such that `cabal v2-build github:github` has everything it needs in the nix store.
