### PR TITLE
relaxed some lower bounds to work with stackage 13.15

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -167,7 +167,7 @@ library
     , binary-instances      >=1          && <1.1
     , cryptohash-sha1       >=0.11.100.1 && <0.12
     , deepseq-generics      >=0.2.0.0    && <0.3
-    , exceptions            >=0.10.2     && <0.11
+    , exceptions            >=0.10.1     && <0.11
     , hashable              >=1.2.7.0    && <1.4
     , http-client           >=0.5.12     && <0.7
     , http-link-header      >=1.0.3.1    && <1.1
@@ -175,8 +175,8 @@ library
     , iso8601-time          >=0.1.5      && <0.2
     , network-uri           >=2.6.1.0    && <2.7
     , tagged                >=0.8.5      && <0.9
-    , transformers-compat   >=0.6.5      && <0.7
-    , unordered-containers  >=0.2.10.0   && <0.3
+    , transformers-compat   >=0.6.2      && <0.7
+    , unordered-containers  >=0.2.9.0    && <0.3
     , vector                >=0.12.0.1   && <0.13
     , vector-instances      >=3.4        && <3.5
 
@@ -200,7 +200,7 @@ test-suite github-test
   hs-source-dirs:     spec
   main-is:            Spec.hs
   ghc-options:        -Wall -threaded
-  build-tool-depends: hspec-discover:hspec-discover >=2.7.1 && <2.8
+  build-tool-depends: hspec-discover:hspec-discover >=2.6.1 && <2.8
   other-extensions:   TemplateHaskell
   other-modules:
     GitHub.ActivitySpec


### PR DESCRIPTION
If I add a `stack.yaml` with some `extra-deps` this builds and passes tests. This enables it to be used as a dependency more easily in other stackage-based projects.