### PR TITLE
Add deleteReference

### DIFF
--- a/src/GitHub/Data/GitData.hs
+++ b/src/GitHub/Data/GitData.hs
@@ -156,7 +156,7 @@ instance Binary NewGitReference
 data GitReference = GitReference
     { gitReferenceObject :: !GitObject
     , gitReferenceUrl    :: !URL
-    , gitReferenceRef    :: !Text
+    , gitReferenceRef    :: !(Name GitReference)
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 

--- a/src/GitHub/Endpoints/GitData/References.hs
+++ b/src/GitHub/Endpoints/GitData/References.hs
@@ -15,6 +15,8 @@ module GitHub.Endpoints.GitData.References (
     referencesR,
     createReference,
     createReferenceR,
+    deleteReference,
+    deleteReferenceR,
     namespacedReferences,
     module GitHub.Data,
     ) where
@@ -72,6 +74,17 @@ createReference auth user repo newRef =
 createReferenceR :: Name Owner -> Name Repo -> NewGitReference -> Request 'RW GitReference
 createReferenceR user repo newRef =
      command Post  ["repos", toPathPart user, toPathPart repo , "git", "refs"] (encode newRef)
+
+-- | Delete a reference.
+deleteReference :: Auth -> Name Owner -> Name Repo -> Name GitReference -> IO (Either Error ())
+deleteReference auth user repo ref =
+    executeRequest auth $ deleteReferenceR user repo ref
+
+-- | Delete a reference.
+-- See <https://developer.github.com/v3/git/refs/#delete-a-reference>
+deleteReferenceR :: Name Owner -> Name Repo -> Name GitReference -> GenRequest 'MtUnit 'RW ()
+deleteReferenceR user repo ref =
+    Command Delete ["repos", toPathPart user, toPathPart repo , "git", "refs", toPathPart ref] mempty
 
 -- | Limited references by a namespace.
 --


### PR DESCRIPTION
NOTE: I'm not sure if passing a `Name GitReference` is right, or if I should pass a full `GitReference`.

For example, deleting a branch works with this code: `deleteReference auth owner repo "heads/some-branch"`. If I were required to pass a full `GitReference`, I'd have to either fake one or somehow have fetched it via a prior API call. This limitation is why I did what I did here, FWIW.