### PR TITLE
Make reactions accessible

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -95,6 +95,7 @@ library
     GitHub.Data.PublicSSHKeys
     GitHub.Data.PullRequests
     GitHub.Data.RateLimit
+    GitHub.Data.Reactions
     GitHub.Data.Releases
     GitHub.Data.Repos
     GitHub.Data.Request

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -219,6 +219,9 @@ module GitHub (
     -- * Delete a comment
     pullRequestCommentsR,
     pullRequestCommentR,
+    pullRequestCommentsWithReactionsR,
+    pullRequestCommentsWithReactionsIO,
+    pullRequestCommentsIO,
     createPullCommentR,
 
     -- ** Pull request reviews

--- a/src/GitHub/Data/Comments.hs
+++ b/src/GitHub/Data/Comments.hs
@@ -7,6 +7,7 @@ module GitHub.Data.Comments where
 
 import GitHub.Data.Definitions
 import GitHub.Data.Id          (Id)
+import GitHub.Data.Reactions   (Reactions)
 import GitHub.Data.URL         (URL)
 import GitHub.Internal.Prelude
 import Prelude ()
@@ -23,6 +24,7 @@ data Comment = Comment
     , commentPath      :: !(Maybe Text)
     , commentUser      :: !SimpleUser
     , commentId        :: !(Id Comment)
+    , commentReactions :: !(Maybe Reactions)
     }
   deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
@@ -42,6 +44,7 @@ instance FromJSON Comment where
         <*> o .:? "path"
         <*> o .: "user"
         <*> o .: "id"
+        <*> o .:? "reactions"
 
 data NewComment = NewComment
     { newCommentBody :: !Text

--- a/src/GitHub/Data/Reactions.hs
+++ b/src/GitHub/Data/Reactions.hs
@@ -1,0 +1,39 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+--
+module GitHub.Data.Reactions where
+
+import GitHub.Data.URL         (URL)
+import GitHub.Internal.Prelude
+import Prelude ()
+
+data Reactions = Reactions
+    { reactionsUrl      :: !URL
+    , reactionsCount    :: !Int
+    , reactionsPlus1    :: !Int
+    , reactionsMinus1   :: !Int
+    , reactionsLaugh    :: !Int
+    , reactionsHooray   :: !Int
+    , reactionsConfused :: !Int
+    , reactionsHeart    :: !Int
+    , reactionsRocket   :: !Int
+    , reactionsEyes     :: !Int
+    }
+  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance FromJSON Reactions where
+    parseJSON = withObject "Reactions" $ \o -> Reactions
+        <$> o .: "url"
+        <*> o .:? "total_count" .!= 0
+        <*> o .:? "+1"          .!= 0
+        <*> o .:? "-1"          .!= 0
+        <*> o .:? "laugh"       .!= 0
+        <*> o .:? "hooray"      .!= 0
+        <*> o .:? "confused"    .!= 0
+        <*> o .:? "heart"       .!= 0
+        <*> o .:? "rocket"      .!= 0
+        <*> o .:? "eyes"        .!= 0
+
+instance NFData Reactions where rnf = genericRnf
+instance Binary Reactions

--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -116,6 +116,7 @@ data MediaType a
     | MtStatus     -- ^ Parse status
     | MtUnit       -- ^ Always succeeds
     | MtPreview  a -- ^ Some other (preview) type; this is an extension point.
+    | MtReactions  -- ^ application/vnd.github.squirrel-girl-preview+json
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 ------------------------------------------------------------------------------
@@ -147,8 +148,8 @@ instance IReadOnly 'RA        where iro = ROA
 
 -- | Github request data type.
 --
--- * @rw@ describes whether authentication is required. It's required for non-@GET@ requests.
 -- * @mt@ describes the media type, i.e. how the response should be interpreted.
+-- * @rw@ describes whether authentication is required. It's required for non-@GET@ requests.
 -- * @a@ is the result type
 --
 -- /Note:/ 'Request' is not 'Functor' on purpose.
@@ -174,7 +175,7 @@ type Request = GenRequest 'MtJSON
 query :: Paths -> QueryString -> Request mt a
 query ps qs = Query ps qs
 
-pagedQuery :: FromJSON a => Paths -> QueryString -> FetchCount -> Request mt (Vector a)
+pagedQuery :: FromJSON a => Paths -> QueryString -> FetchCount -> Request rw (Vector a)
 pagedQuery ps qs fc = PagedQuery ps qs fc
 
 command :: CommandMethod -> Paths -> LBS.ByteString -> Request 'RW a
@@ -184,11 +185,11 @@ command m ps body = Command m ps body
 -- Instances
 -------------------------------------------------------------------------------
 
-deriving instance Eq (GenRequest rw mt a)
-deriving instance Ord (GenRequest rw mt a)
-deriving instance Show (GenRequest rw mt a)
+deriving instance Eq (GenRequest mt rw a)
+deriving instance Ord (GenRequest mt rw a)
+deriving instance Show (GenRequest mt rw a)
 
-instance Hashable (GenRequest rw mt a) where
+instance Hashable (GenRequest mt rw a) where
     hashWithSalt salt (Query ps qs) =
         salt `hashWithSalt` (0 :: Int)
              `hashWithSalt` ps

--- a/src/GitHub/Endpoints/PullRequests/Comments.hs
+++ b/src/GitHub/Endpoints/PullRequests/Comments.hs
@@ -8,6 +8,8 @@
 module GitHub.Endpoints.PullRequests.Comments (
     pullRequestCommentsIO,
     pullRequestCommentsR,
+    pullRequestCommentsWithReactionsIO,
+    pullRequestCommentsWithReactionsR,
     pullRequestComment,
     pullRequestCommentR,
     createPullComment,
@@ -22,7 +24,7 @@ import Prelude ()
 
 -- | All the comments on a pull request with the given ID.
 --
--- > pullRequestComments "thoughtbot" "factory_girl" (Id 256)
+-- > pullRequestCommentsIO "thoughtbot" "factory_girl" (IssueNumber 256)
 pullRequestCommentsIO :: Name Owner -> Name Repo -> IssueNumber -> IO (Either Error (Vector Comment))
 pullRequestCommentsIO user repo prid =
     executeRequest' $ pullRequestCommentsR user repo prid FetchAll
@@ -32,6 +34,19 @@ pullRequestCommentsIO user repo prid =
 pullRequestCommentsR :: Name Owner -> Name Repo -> IssueNumber -> FetchCount -> Request k (Vector Comment)
 pullRequestCommentsR user repo prid =
     pagedQuery ["repos", toPathPart user, toPathPart repo, "pulls", toPathPart prid, "comments"] []
+
+-- | All the comments and their reactions in a pull request with a given ID.
+--
+-- > pullRequestCommentsWithReactionsIO "thoughtbot" "factory_girl" (IssueNumber 256)
+pullRequestCommentsWithReactionsIO :: Name Owner -> Name Repo -> IssueNumber -> IO (Either Error (Vector Comment))
+pullRequestCommentsWithReactionsIO user repo prid =
+    executeRequest' $ pullRequestCommentsWithReactionsR user repo prid FetchAll
+
+-- | List comments on a pull request as well as the reactions.
+-- See <https://developer.github.com/v3/reactions>
+pullRequestCommentsWithReactionsR :: Name Owner -> Name Repo -> IssueNumber -> FetchCount -> GenRequest 'MtReactions k (Vector Comment)
+pullRequestCommentsWithReactionsR user repo prid =
+    PagedQuery ["repos", toPathPart user, toPathPart repo, "pulls", toPathPart prid, "comments"] []
 
 -- | One comment on a pull request, by the comment's ID.
 --

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -240,6 +240,9 @@ instance Accept 'MtJSON where
 instance FromJSON a => ParseResponse 'MtJSON a where
     parseResponse _ res = Tagged (parseResponseJSON res)
 
+instance FromJSON a => ParseResponse 'MtReactions a where
+    parseResponse _ res = Tagged (parseResponseJSON res)
+
 instance Accept 'MtStar where
     contentType = Tagged "application/vnd.github.v3.star+json"
 
@@ -254,6 +257,7 @@ instance Accept 'MtRaw   where contentType = Tagged "application/vnd.github.v3.r
 instance Accept 'MtDiff  where contentType = Tagged "application/vnd.github.v3.diff"
 instance Accept 'MtPatch where contentType = Tagged "application/vnd.github.v3.patch"
 instance Accept 'MtSha   where contentType = Tagged "application/vnd.github.v3.sha"
+instance Accept 'MtReactions where contentType = Tagged "application/vnd.github.squirrel-girl-preview+json"
 
 instance a ~ LBS.ByteString => ParseResponse 'MtRaw   a where parseResponse _ = Tagged . return . responseBody
 instance a ~ LBS.ByteString => ParseResponse 'MtDiff  a where parseResponse _ = Tagged . return . responseBody


### PR DESCRIPTION
Reasons to accept this pull request:

* It uses the github preview accept header to get reactions information on pull request comments
* It fixes some type argument names that were misleading

Reasons to hate this pull request:

* It isn't clean, it fixes type argument names instead of focusing on one thing.
* It generalizes the type of pageQuery
* It isn't perfect in-so-far as the lack of reactions information on issue comments is now glaring.

All bugs are mine, not Matt's who's name appears on commits and who's patches I refactored to arrive here.