### PR TITLE
Add missing attributes to event type.

### DIFF
--- a/src/GitHub/Data/Definitions.hs
+++ b/src/GitHub/Data/Definitions.hs
@@ -38,6 +38,15 @@ data OwnerType = OwnerUser | OwnerOrganization
 instance NFData OwnerType
 instance Binary OwnerType
 
+data SimpleRepo = SimpleRepo
+    { simpleRepoId   :: !(Id SimpleRepo)
+    , simpleRepoName :: !(Name SimpleRepo)
+    , simpleRepoUrl  :: !URL
+    } deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData SimpleRepo where rnf = genericRnf
+instance Binary SimpleRepo
+
 data SimpleUser = SimpleUser
     { simpleUserId        :: !(Id User)
     , simpleUserLogin     :: !(Name User)
@@ -138,6 +147,13 @@ instance FromJSON OwnerType where
         "user"         -> pure $ OwnerUser
         "organization" -> pure $ OwnerOrganization
         _              -> fail $ "Unknown OwnerType: " <> T.unpack t
+
+instance FromJSON SimpleRepo where
+    parseJSON = withObject "SimpleRepo" $ \obj -> do
+        SimpleRepo
+            <$> obj .: "id"
+            <*> obj .: "name"
+            <*> obj .: "url"
 
 instance FromJSON SimpleUser where
     parseJSON = withObject "SimpleUser" $ \obj -> do

--- a/src/GitHub/Data/Events.hs
+++ b/src/GitHub/Data/Events.hs
@@ -13,13 +13,13 @@ import Prelude ()
 --
 -- /TODO:/
 --
--- * missing org, payload, id
+-- * missing org, payload
 data Event = Event
-    -- { eventId        :: !(Id Event) -- id can be encoded as string.
     { eventActor     :: !SimpleUser
     , eventCreatedAt :: !UTCTime
     , eventPublic    :: !Bool
     , eventRepo      :: !SimpleRepo
+    , eventId        :: !Text
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
@@ -28,8 +28,8 @@ instance Binary Event
 
 instance FromJSON Event where
     parseJSON = withObject "Event" $ \obj -> Event
-        -- <$> obj .: "id"
         <$> obj .: "actor"
         <*> obj .: "created_at"
         <*> obj .: "public"
         <*> obj .: "repo"
+        <*> obj .: "id"

--- a/src/GitHub/Data/Events.hs
+++ b/src/GitHub/Data/Events.hs
@@ -20,6 +20,7 @@ data Event = Event
     , eventPublic    :: !Bool
     , eventRepo      :: !SimpleRepo
     , eventId        :: !Text
+    , eventType      :: !ActivityEvent
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
@@ -33,3 +34,60 @@ instance FromJSON Event where
         <*> obj .: "public"
         <*> obj .: "repo"
         <*> obj .: "id"
+        <*> obj .: "type"
+
+-- See <https://developer.github.com/v3/activity/events/types/>
+data ActivityEvent =
+      CheckRunEvent
+    | CheckSuiteEvent
+    | CommitCommentEvent
+    | ContentReferenceEvent
+    | CreateEvent
+    | DeleteEvent
+    | DeployKeyEvent
+    | DeploymentEvent
+    | DeploymentStatusEvent
+    | DownloadEvent
+    | FollowEvent
+    | ForkEvent
+    | ForkApplyEvent
+    | GitHubAppAuthorizationEvent
+    | GistEvent
+    | GollumEvent
+    | InstallationEvent
+    | InstallationRepositoriesEvent
+    | IssueCommentEvent
+    | IssuesEvent
+    | LabelEvent
+    | MarketplacePurchaseEvent
+    | MemberEvent
+    | MembershipEvent
+    | MetaEvent
+    | MilestoneEvent
+    | OrganizationEvent
+    | OrgBlockEvent
+    | PageBuildEvent
+    | ProjectCardEvent
+    | ProjectColumnEvent
+    | ProjectEvent
+    | PublicEvent
+    | PullRequestEvent'
+    | PullRequestReviewEvent
+    | PullRequestReviewCommentEvent
+    | PushEvent
+    | RegistryPackageEvent
+    | ReleaseEvent
+    | RepositoryEvent
+    | RepositoryImportEvent
+    | RepositoryVulnerabilityAlertEvent
+    | SecurityAdvisoryEvent
+    | StarEvent
+    | StatusEvent
+    | TeamEvent
+    | TeamAddEvent
+    | WatchEvent
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance FromJSON ActivityEvent
+instance NFData ActivityEvent where rnf = genericRnf
+instance Binary ActivityEvent

--- a/src/GitHub/Data/Events.hs
+++ b/src/GitHub/Data/Events.hs
@@ -13,21 +13,23 @@ import Prelude ()
 --
 -- /TODO:/
 --
--- * missing repo, org, payload, id
+-- * missing org, payload, id
 data Event = Event
     -- { eventId        :: !(Id Event) -- id can be encoded as string.
     { eventActor     :: !SimpleUser
     , eventCreatedAt :: !UTCTime
     , eventPublic    :: !Bool
+    , eventRepo      :: !SimpleRepo
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
 instance NFData Event where rnf = genericRnf
-instance Binary Event 
+instance Binary Event
 
 instance FromJSON Event where
-    parseJSON = withObject "Event" $ \obj -> Event 
+    parseJSON = withObject "Event" $ \obj -> Event
         -- <$> obj .: "id"
         <$> obj .: "actor"
         <*> obj .: "created_at"
         <*> obj .: "public"
+        <*> obj .: "repo"


### PR DESCRIPTION
These were all relatively simple changes, although I'd like to confirm the new `eventType` field on the `Event` data type.

It seems like events can be scoped to different constructs. For example, there are [activity events](https://developer.github.com/v3/activity/events/), which is the type of event we are modifying here. There are also [events scoped to issues](https://developer.github.com/v3/issues/events/). These two types of events are separate from each other (at least that is my understanding).

Also, each "activity event" has its own payload, which has not been implemented yet. 