### PR TITLE
Remove redundant withOpenSSL

### DIFF
--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -129,7 +129,7 @@ executeRequest
     => am
     -> GenRequest mt rw a
     -> IO (Either Error a)
-executeRequest auth req = withOpenSSL $ withOpenSSL $ do
+executeRequest auth req = withOpenSSL $ do
     manager <- newManager tlsManagerSettings
     executeRequestWithMgr manager auth req
 


### PR DESCRIPTION
Unless it was intentional? I didn't find anything about double application in its documentation.