### PR TITLE
Teams improvements

### DIFF
--- a/samples/Organizations/Teams/CreateTeamFor.hs
+++ b/samples/Organizations/Teams/CreateTeamFor.hs
@@ -13,7 +13,7 @@ main = do
                 Github.createTeamFor'
                   (Github.OAuth token)
                   org
-                  (Github.CreateTeam team (Just desc) (read repos :: [String]) Github.PermissionPull)
+                  (Github.CreateTeam team (Just desc) (read repos :: [String]) Nothing Github.PermissionPull)
               _                               ->
                 error "usage: CreateTeamFor <token> <org> <team_name> <description> <[\"repos\"]>"
   case result of

--- a/samples/Organizations/Teams/CreateTeamFor.hs
+++ b/samples/Organizations/Teams/CreateTeamFor.hs
@@ -13,7 +13,7 @@ main = do
                 Github.createTeamFor'
                   (Github.OAuth token)
                   org
-                  (Github.CreateTeam team (Just desc) (read repos :: [String]) Nothing Github.PermissionPull)
+                  (Github.CreateTeam team (Just desc) (read repos :: [String]) Github.PrivacyClosed Github.PermissionPull)
               _                               ->
                 error "usage: CreateTeamFor <token> <org> <team_name> <description> <[\"repos\"]>"
   case result of

--- a/samples/Teams/EditTeam.hs
+++ b/samples/Teams/EditTeam.hs
@@ -15,7 +15,7 @@ main = do
                   (GitHub.OAuth $ fromString token)
                   GitHub.editTeamR
                   (GitHub.mkTeamId $ read team_id)
-                  (GitHub.EditTeam (GitHub.mkTeamName $ fromString team_name) (Just $ fromString desc) GitHub.PermissionPull)
+                  (GitHub.EditTeam (GitHub.mkTeamName $ fromString team_name) (Just $ fromString desc) Nothing GitHub.PermissionPull)
               _                                 ->
                 error "usage: EditTeam <token> <team_id> <team_name> <description>"
   case result of

--- a/samples/Teams/EditTeam.hs
+++ b/samples/Teams/EditTeam.hs
@@ -15,7 +15,7 @@ main = do
                   (GitHub.OAuth $ fromString token)
                   GitHub.editTeamR
                   (GitHub.mkTeamId $ read team_id)
-                  (GitHub.EditTeam (GitHub.mkTeamName $ fromString team_name) (Just $ fromString desc) Nothing GitHub.PermissionPull)
+                  (GitHub.EditTeam (GitHub.mkTeamName $ fromString team_name) (Just $ fromString desc) Nothing Nothing)
               _                                 ->
                 error "usage: EditTeam <token> <team_id> <team_name> <description>"
   case result of

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -50,7 +50,7 @@ data SimpleTeam = SimpleTeam
     , simpleTeamName            :: !Text  -- TODO (0.15.0): unify this and 'simpleTeamSlug' as in 'Team'.
     , simpleTeamSlug            :: !(Name Team)
     , simpleTeamDescription     :: !(Maybe Text)
-    , simpleTeamPrivacy         :: !(Maybe Privacy)
+    , simpleTeamPrivacy         :: !Privacy
     , simpleTeamPermission      :: !Permission
     , simpleTeamMembersUrl      :: !URL
     , simpleTeamRepositoriesUrl :: !URL
@@ -66,7 +66,7 @@ data Team = Team
     , teamName            :: !Text
     , teamSlug            :: !(Name Team)
     , teamDescription     :: !(Maybe Text)
-    , teamPrivacy         :: !(Maybe Privacy)
+    , teamPrivacy         :: !Privacy
     , teamPermission      :: !Permission
     , teamMembersUrl      :: !URL
     , teamRepositoriesUrl :: !URL
@@ -144,7 +144,7 @@ instance FromJSON SimpleTeam where
         <*> o .: "name"
         <*> o .: "slug"
         <*> o .:?"description" .!= Nothing
-        <*> o .:?"privacy" .!= Nothing
+        <*> o .: "privacy"
         <*> o .: "permission"
         <*> o .: "members_url"
         <*> o .: "repositories_url"
@@ -156,7 +156,7 @@ instance FromJSON Team where
         <*> o .: "name"
         <*> o .: "slug"
         <*> o .:?"description" .!= Nothing
-        <*> o .:?"privacy" .!= Nothing
+        <*> o .: "privacy"
         <*> o .: "permission"
         <*> o .: "members_url"
         <*> o .: "repositories_url"

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -165,21 +165,29 @@ instance FromJSON Team where
         <*> o .: "organization"
 
 instance ToJSON CreateTeam where
-  toJSON (CreateTeam name desc repo_names privacy permission) =
-    object [ "name"        .= name
-           , "description" .= desc
-           , "repo_names"  .= repo_names
-           , "privacy"     .= privacy
-           , "permission"  .= permission
-           ]
+    toJSON (CreateTeam name desc repo_names privacy permission) =
+        object $ filter notNull
+            [ "name"        .= name
+            , "description" .= desc
+            , "repo_names"  .= repo_names
+            , "privacy"     .= privacy
+            , "permission"  .= permission
+            ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
 
 instance ToJSON EditTeam where
-  toJSON (EditTeam name desc privacy permission) =
-    object [ "name"        .= name
-           , "description" .= desc
-           , "privacy"     .= privacy
-           , "permission"  .= permission
-           ]
+    toJSON (EditTeam name desc privacy permission) =
+        object $ filter notNull
+            [ "name"        .= name
+            , "description" .= desc
+            , "privacy"     .= privacy
+            , "permission"  .= permission
+            ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
 
 instance FromJSON TeamMembership where
     parseJSON = withObject "TeamMembership" $ \o -> TeamMembership

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -83,7 +83,7 @@ data CreateTeam = CreateTeam
     { createTeamName        :: !(Name Team)
     , createTeamDescription :: !(Maybe Text)
     , createTeamRepoNames   :: !(Vector (Name Repo))
-    -- , createTeamPrivacy    :: Privacy
+    , createTeamPrivacy     :: !(Maybe Privacy)
     , createTeamPermission  :: !Permission
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
@@ -94,7 +94,7 @@ instance Binary CreateTeam
 data EditTeam = EditTeam
     { editTeamName        :: !(Name Team)
     , editTeamDescription :: !(Maybe Text)
-    -- , editTeamPrivacy :: Privacy
+    , editTeamPrivacy     :: !(Maybe Privacy)
     , editTeamPermission  :: !Permission
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
@@ -165,19 +165,19 @@ instance FromJSON Team where
         <*> o .: "organization"
 
 instance ToJSON CreateTeam where
-  toJSON (CreateTeam name desc repo_names {-privacy-} permission) =
+  toJSON (CreateTeam name desc repo_names privacy permission) =
     object [ "name"        .= name
            , "description" .= desc
            , "repo_names"  .= repo_names
-           {-, "privacy" .= privacy-}
+           , "privacy"     .= privacy
            , "permission"  .= permission
            ]
 
 instance ToJSON EditTeam where
-  toJSON (EditTeam name desc {-privacy-} permission) =
+  toJSON (EditTeam name desc privacy permission) =
     object [ "name"        .= name
            , "description" .= desc
-           {-, "privacy" .= privacy-}
+           , "privacy"     .= privacy
            , "permission"  .= permission
            ]
 

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -84,7 +84,7 @@ data CreateTeam = CreateTeam
     , createTeamDescription :: !(Maybe Text)
     , createTeamRepoNames   :: !(Vector (Name Repo))
     -- , createTeamPrivacy    :: Privacy
-    , createTeamPermission  :: Permission
+    , createTeamPermission  :: !Permission
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 
@@ -165,19 +165,21 @@ instance FromJSON Team where
         <*> o .: "organization"
 
 instance ToJSON CreateTeam where
-  toJSON (CreateTeam name desc repo_names {-privacy-} permissions) =
+  toJSON (CreateTeam name desc repo_names {-privacy-} permission) =
     object [ "name"        .= name
            , "description" .= desc
            , "repo_names"  .= repo_names
            {-, "privacy" .= privacy-}
-           , "permissions" .= permissions ]
+           , "permission"  .= permission
+           ]
 
 instance ToJSON EditTeam where
-  toJSON (EditTeam name desc {-privacy-} permissions) =
+  toJSON (EditTeam name desc {-privacy-} permission) =
     object [ "name"        .= name
            , "description" .= desc
            {-, "privacy" .= privacy-}
-           , "permissions" .= permissions ]
+           , "permission"  .= permission
+           ]
 
 instance FromJSON TeamMembership where
     parseJSON = withObject "TeamMembership" $ \o -> TeamMembership

--- a/src/GitHub/Data/Teams.hs
+++ b/src/GitHub/Data/Teams.hs
@@ -83,7 +83,7 @@ data CreateTeam = CreateTeam
     { createTeamName        :: !(Name Team)
     , createTeamDescription :: !(Maybe Text)
     , createTeamRepoNames   :: !(Vector (Name Repo))
-    , createTeamPrivacy     :: !(Maybe Privacy)
+    , createTeamPrivacy     :: !Privacy
     , createTeamPermission  :: !Permission
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
@@ -95,7 +95,7 @@ data EditTeam = EditTeam
     { editTeamName        :: !(Name Team)
     , editTeamDescription :: !(Maybe Text)
     , editTeamPrivacy     :: !(Maybe Privacy)
-    , editTeamPermission  :: !Permission
+    , editTeamPermission  :: !(Maybe Permission)
     }
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
 


### PR DESCRIPTION
Three changes:

#### Fix permission field in types for teams

Fixes a bug as the field is [`permission`](https://developer.github.com/v3/teams/#create-team) not `permissions`.

#### Add privacy field to types for teams

The privacy field was previously commented out while the privacy level of a team was part of the `ironman` API preview. This feature is now [part of the official v3 API](https://developer.github.com/changes/2016-01-05-api-enhancements-for-working-with-organization-permissions-are-now-official/), so this commit adds support for this field.

#### Make privacy field non-optional in teams

The `privacy` field is optional when creating/editing teams, but has a context dependent default value. When getting the team details, the field is expected to always be populated due to these default values.

----

I could also add the `ldap_dn` field mentioned in #416 as part of this pull request, but I chose not to as I suspect you may not want to support undocumented fields.