### PR TITLE
Add openssl flag to samples

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,3 +8,4 @@ constraints: hashable ^>=1.3
 constraints: semigroups ^>=0.19
 
 constraints: github +openssl
+constraints: github-samples +openssl

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -17,6 +17,11 @@ tested-with:
    || ==8.6.5
    || ==8.8.1
 
+flag openssl
+  description: "Use http-client-openssl"
+  manual:  True
+  default: False
+
 library
   hs-source-dirs:   src
   ghc-options:      -Wall
@@ -38,14 +43,21 @@ executable github-operational
     , base-compat-batteries
     , github
     , github-samples
-    , HsOpenSSL
-    , HsOpenSSL-x509-system
     , http-client
-    , http-client-openssl
     , operational
     , text
     , transformers
     , transformers-compat
+
+  if flag(openssl)
+    build-depends:
+        HsOpenSSL
+      , HsOpenSSL-x509-system
+      , http-client-openssl
+
+  else
+    build-depends:
+        http-client-tls
 
   default-language: Haskell2010
 


### PR DESCRIPTION
The samples fail to build on a machine that doesn't have `openssl` installed, so I thought maybe we should use the same approach used in the main library (refer to #378) to toggle between `http-client-tls` and `http-client-openssl`.