### PR TITLE
Manage orgs in GitHub Enterprise

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -90,6 +90,7 @@ library
     GitHub.Data.DeployKeys
     GitHub.Data.Deployments
     GitHub.Data.Email
+    GitHub.Data.Enterprise.Organizations
     GitHub.Data.Events
     GitHub.Data.Gists
     GitHub.Data.GitData
@@ -116,6 +117,7 @@ library
     GitHub.Endpoints.Activity.Notifications
     GitHub.Endpoints.Activity.Starring
     GitHub.Endpoints.Activity.Watching
+    GitHub.Endpoints.Enterprise.Organizations
     GitHub.Endpoints.Gists
     GitHub.Endpoints.Gists.Comments
     GitHub.Endpoints.GitData.Blobs

--- a/github.cabal
+++ b/github.cabal
@@ -90,6 +90,7 @@ library
     GitHub.Data.DeployKeys
     GitHub.Data.Deployments
     GitHub.Data.Email
+    GitHub.Data.Enterprise
     GitHub.Data.Enterprise.Organizations
     GitHub.Data.Events
     GitHub.Data.Gists
@@ -153,6 +154,7 @@ library
     GitHub.Endpoints.Users.Emails
     GitHub.Endpoints.Users.Followers
     GitHub.Endpoints.Users.PublicSSHKeys
+    GitHub.Enterprise
     GitHub.Internal.Prelude
     GitHub.Request
 

--- a/samples/Enterprise/CreateOrganization.hs
+++ b/samples/Enterprise/CreateOrganization.hs
@@ -5,6 +5,7 @@ module Main (main) where
 import Common
 
 import qualified GitHub
+import qualified GitHub.Enterprise as GitHub
 
 main :: IO ()
 main = do

--- a/samples/Enterprise/CreateOrganization.hs
+++ b/samples/Enterprise/CreateOrganization.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import Common
+
+import qualified GitHub
+
+main :: IO ()
+main = do
+  args <- getArgs
+  result <- case args of
+              [api_endpoint, token, org_login, org_admin, org_profile_name] ->
+                GitHub.github
+                  (GitHub.EnterpriseOAuth
+                    (fromString api_endpoint)
+                    (fromString token)
+                  )
+                  GitHub.createOrganizationR
+                  (GitHub.CreateOrganization
+                    (GitHub.mkOrganizationName $ fromString org_login)
+                    (GitHub.mkUserName $ fromString org_admin)
+                    (Just $ fromString org_profile_name)
+                  )
+              _                                 ->
+                error "usage: CreateOrganization <api_endpoint> <token> <org_login> <org_admin> <org_profile_name>"
+  case result of
+    Left err  -> putStrLn $ "Error: " <> tshow err
+    Right org -> putStrLn $ tshow org

--- a/samples/Enterprise/RenameOrganization.hs
+++ b/samples/Enterprise/RenameOrganization.hs
@@ -5,6 +5,7 @@ module Main (main) where
 import Common
 
 import qualified GitHub
+import qualified GitHub.Enterprise as GitHub
 
 main :: IO ()
 main = do

--- a/samples/Enterprise/RenameOrganization.hs
+++ b/samples/Enterprise/RenameOrganization.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import Common
+
+import qualified GitHub
+
+main :: IO ()
+main = do
+  args <- getArgs
+  result <- case args of
+              [api_endpoint, token, current_name, new_name] ->
+                GitHub.github
+                  (GitHub.EnterpriseOAuth
+                    (fromString api_endpoint)
+                    (fromString token)
+                  )
+                  GitHub.renameOrganizationR
+                  (GitHub.mkOrganizationName $ fromString current_name)
+                  (GitHub.RenameOrganization
+                    (GitHub.mkOrganizationName $ fromString new_name)
+                  )
+              _                                 ->
+                error "usage: RenameOrganization <api_endpoint> <token> <current_name> <new_name>"
+  case result of
+    Left err -> putStrLn $ "Error: " <> tshow err
+    Right x  -> putStrLn $ tshow x

--- a/samples/github-samples.cabal
+++ b/samples/github-samples.cabal
@@ -98,6 +98,16 @@ executable github-create-deploy-key
 --   main-is:        DeleteTeamMembershipFor.hs
 --   hs-source-dirs: Teams/Memberships
 
+executable github-enterprise-create-organization
+  import:         deps
+  main-is:        CreateOrganization.hs
+  hs-source-dirs: Enterprise
+
+executable github-enterprise-rename-organization
+  import:         deps
+  main-is:        RenameOrganization.hs
+  hs-source-dirs: Enterprise
+
 executable github-edit-team
   import:         deps
   main-is:        EditTeam.hs

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -56,6 +56,14 @@ module GitHub (
     watchersForR,
     reposWatchedByR,
 
+    -- * Enterprise
+    -- | See <https://developer.github.com/enterprise/v3/enterprise-admin/>
+
+    -- ** Organizations
+    -- | See <https://developer.github.com/enterprise/v3/enterprise-admin/orgs/>
+    createOrganizationR,
+    renameOrganizationR,
+
     -- * Gists
     -- | See <https://developer.github.com/v3/gists/>
     --
@@ -401,6 +409,7 @@ import GitHub.Endpoints.Activity.Events
 import GitHub.Endpoints.Activity.Notifications
 import GitHub.Endpoints.Activity.Starring
 import GitHub.Endpoints.Activity.Watching
+import GitHub.Endpoints.Enterprise.Organizations
 import GitHub.Endpoints.Gists
 import GitHub.Endpoints.Gists.Comments
 import GitHub.Endpoints.GitData.Blobs

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -3,7 +3,7 @@
 -- License     :  BSD-3-Clause
 -- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
 --
--- This module re-exports all request constructrors and data definitions from
+-- This module re-exports all request constructors and data definitions from
 -- this package.
 --
 -- See "GitHub.Request" module for executing 'Request', in short

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -41,6 +41,7 @@ module GitHub.Data (
     module GitHub.Data.DeployKeys,
     module GitHub.Data.Deployments,
     module GitHub.Data.Email,
+    module GitHub.Data.Enterprise.Organizations,
     module GitHub.Data.Events,
     module GitHub.Data.Gists,
     module GitHub.Data.GitData,
@@ -73,6 +74,7 @@ import GitHub.Data.Definitions
 import GitHub.Data.DeployKeys
 import GitHub.Data.Deployments
 import GitHub.Data.Email
+import GitHub.Data.Enterprise.Organizations
 import GitHub.Data.Events
 import GitHub.Data.Gists
 import GitHub.Data.GitData

--- a/src/GitHub/Data.hs
+++ b/src/GitHub/Data.hs
@@ -41,7 +41,6 @@ module GitHub.Data (
     module GitHub.Data.DeployKeys,
     module GitHub.Data.Deployments,
     module GitHub.Data.Email,
-    module GitHub.Data.Enterprise.Organizations,
     module GitHub.Data.Events,
     module GitHub.Data.Gists,
     module GitHub.Data.GitData,
@@ -74,7 +73,6 @@ import GitHub.Data.Definitions
 import GitHub.Data.DeployKeys
 import GitHub.Data.Deployments
 import GitHub.Data.Email
-import GitHub.Data.Enterprise.Organizations
 import GitHub.Data.Events
 import GitHub.Data.Gists
 import GitHub.Data.GitData

--- a/src/GitHub/Data/Enterprise.hs
+++ b/src/GitHub/Data/Enterprise.hs
@@ -1,0 +1,12 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+-- This module re-exports the @GitHub.Data.Enterprise.@ submodules.
+module GitHub.Data.Enterprise (
+    -- * Module re-exports
+    module GitHub.Data.Enterprise.Organizations,
+    ) where
+
+import GitHub.Data.Enterprise.Organizations

--- a/src/GitHub/Data/Enterprise/Organizations.hs
+++ b/src/GitHub/Data/Enterprise/Organizations.hs
@@ -1,0 +1,64 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+module GitHub.Data.Enterprise.Organizations where
+
+import GitHub.Data.Definitions
+import GitHub.Data.Name (Name)
+import GitHub.Data.URL (URL)
+import GitHub.Internal.Prelude
+import Prelude ()
+
+data CreateOrganization = CreateOrganization
+    { createOrganizationLogin       :: !(Name Organization)
+    , createOrganizationAdmin       :: !(Name User)
+    , createOrganizationProfileName :: !(Maybe Text)
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CreateOrganization where rnf = genericRnf
+instance Binary CreateOrganization
+
+data RenameOrganization = RenameOrganization
+    { renameOrganizationLogin :: !(Name Organization)
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData RenameOrganization where rnf = genericRnf
+instance Binary RenameOrganization
+
+data RenameOrganizationResponse = RenameOrganizationResponse
+    { renameOrganizationResponseMessage :: !Text
+    , renameOrganizationResponseUrl     :: !URL
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData RenameOrganizationResponse where rnf = genericRnf
+instance Binary RenameOrganizationResponse
+
+-- JSON Instances
+
+instance ToJSON CreateOrganization where
+    toJSON (CreateOrganization login admin profileName) =
+        object $ filter notNull
+            [ "login"        .= login
+            , "admin"        .= admin
+            , "profile_name" .= profileName
+            ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance ToJSON RenameOrganization where
+    toJSON (RenameOrganization login) =
+        object
+            [ "login" .= login
+            ]
+
+instance FromJSON RenameOrganizationResponse where
+    parseJSON = withObject "RenameOrganizationResponse" $ \o ->
+        RenameOrganizationResponse
+            <$> o .: "message"
+            <*> o .: "url"

--- a/src/GitHub/Endpoints/Enterprise/Organizations.hs
+++ b/src/GitHub/Endpoints/Enterprise/Organizations.hs
@@ -1,0 +1,27 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+-- The GitHub Enterprise orgs API as described on <https://developer.github.com/enterprise/v3/enterprise-admin/orgs/>.
+module GitHub.Endpoints.Enterprise.Organizations (
+    createOrganizationR,
+    renameOrganizationR,
+    module GitHub.Data,
+    ) where
+
+import GitHub.Data
+import GitHub.Internal.Prelude
+import Prelude ()
+
+-- | Create an organization.
+-- See <https://developer.github.com/enterprise/v3/enterprise-admin/orgs/#create-an-organization>
+createOrganizationR :: CreateOrganization -> Request 'RW SimpleOrganization
+createOrganizationR =
+    command Post ["admin", "organizations"] . encode
+
+-- | Rename an organization.
+-- See <https://developer.github.com/enterprise/v3/enterprise-admin/orgs/#rename-an-organization>
+renameOrganizationR :: Name Organization -> RenameOrganization -> Request 'RW RenameOrganizationResponse
+renameOrganizationR org =
+    command Patch ["admin", "organizations", toPathPart org] . encode

--- a/src/GitHub/Endpoints/Enterprise/Organizations.hs
+++ b/src/GitHub/Endpoints/Enterprise/Organizations.hs
@@ -11,6 +11,7 @@ module GitHub.Endpoints.Enterprise.Organizations (
     ) where
 
 import GitHub.Data
+import GitHub.Data.Enterprise
 import GitHub.Internal.Prelude
 import Prelude ()
 

--- a/src/GitHub/Enterprise.hs
+++ b/src/GitHub/Enterprise.hs
@@ -1,0 +1,23 @@
+-----------------------------------------------------------------------------
+-- |
+-- License     :  BSD-3-Clause
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+-- This module re-exports all request constructors and data definitions for
+-- working with GitHub Enterprise.
+--
+module GitHub.Enterprise (
+    -- * Enterprise Admin
+    -- | See <https://developer.github.com/enterprise/v3/enterprise-admin/>
+
+    -- ** Organizations
+    -- | See <https://developer.github.com/enterprise/v3/enterprise-admin/orgs/>
+    createOrganizationR,
+    renameOrganizationR,
+
+    -- * Data definitions
+    module GitHub.Data.Enterprise,
+    ) where
+
+import GitHub.Data.Enterprise
+import GitHub.Endpoints.Enterprise.Organizations


### PR DESCRIPTION
Adds the two endpoints for [managing orgs in GitHub Enterprise](https://developer.github.com/enterprise/2.19/v3/enterprise-admin/orgs/).

Happy to discuss in this PR whether the `github` library should support GitHub Enterprise features. I've put the first `Organizations` module under `GitHub.Endpoints.Enterprise` to try to make it clear that the endpoint isn't supported in the `github.com` API.