### PR TITLE
Add support for collaborator permission endpoint

### DIFF
--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -258,6 +258,7 @@ module GitHub (
     -- ** Collaborators
     -- | See <https://developer.github.com/v3/repos/collaborators/>
     collaboratorsOnR,
+    collaboratorPermissionOnR,
     isCollaboratorOnR,
     addCollaboratorR,
 

--- a/src/GitHub/Endpoints/Repos/Collaborators.hs
+++ b/src/GitHub/Endpoints/Repos/Collaborators.hs
@@ -7,6 +7,7 @@
 -- <http://developer.github.com/v3/repos/collaborators/>.
 module GitHub.Endpoints.Repos.Collaborators (
     collaboratorsOnR,
+    collaboratorPermissionOnR,
     isCollaboratorOnR,
     addCollaboratorR,
     module GitHub.Data,
@@ -21,6 +22,16 @@ import Prelude ()
 collaboratorsOnR :: Name Owner -> Name Repo -> FetchCount -> Request k (Vector SimpleUser)
 collaboratorsOnR user repo =
     pagedQuery ["repos", toPathPart user, toPathPart repo, "collaborators"] []
+
+-- | Review a user's permission level.
+-- <https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level>
+collaboratorPermissionOnR
+    :: Name Owner        -- ^ Repository owner
+    -> Name Repo         -- ^ Repository name
+    -> Name User         -- ^ Collaborator to check permissions of.
+    -> GenRequest 'MtJSON rw CollaboratorWithPermission
+collaboratorPermissionOnR owner repo coll =
+    query ["repos", toPathPart owner, toPathPart repo, "collaborators", toPathPart coll, "permission"] []
 
 -- | Check if a user is a collaborator.
 -- See <https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator>


### PR DESCRIPTION
[This endpoint](https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level) allows checking whether a collaborator has read, write, or admin permissions. We are using this endpoint in https://github.com/channable/hoff, from this branch, and so far it has been working fine.