### PR TITLE
Generalize PagedQuery to allow its reuse by preview github APIs

### DIFF
--- a/src/GitHub/Data/Request.hs
+++ b/src/GitHub/Data/Request.hs
@@ -154,7 +154,7 @@ instance IReadOnly 'RA        where iro = ROA
 -- /Note:/ 'Request' is not 'Functor' on purpose.
 data GenRequest (mt :: MediaType *) (rw :: RW) a where
     Query        :: Paths -> QueryString -> GenRequest mt rw a
-    PagedQuery   :: Paths -> QueryString -> FetchCount -> GenRequest mt rw (Vector a)
+    PagedQuery   :: (a ~ t b, Foldable t, Semigroup a) => Paths -> QueryString -> FetchCount -> GenRequest mt rw a
 
     -- | Command
     Command

--- a/src/GitHub/Request.hs
+++ b/src/GitHub/Request.hs
@@ -100,7 +100,6 @@ import qualified Data.ByteString              as BS
 import qualified Data.ByteString.Lazy         as LBS
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as TE
-import qualified Data.Vector                  as V
 import qualified Network.HTTP.Client          as HTTP
 import qualified Network.HTTP.Client.Internal as HTTP
 
@@ -242,7 +241,7 @@ executeRequestWithMgrAndRes mgr auth req = runExceptT $ do
     performHttpReq httpReq (PagedQuery _ _ l) =
         unTagged (performPagedRequest httpLbs' predicate httpReq :: Tagged mt (ExceptT Error IO (HTTP.Response b)))
       where
-        predicate v = lessFetchCount (V.length v) l
+        predicate v = lessFetchCount (length v) l
 
     performHttpReq httpReq (Command _ _ _) = do
         res <- httpLbs' httpReq


### PR DESCRIPTION
I've been greatly enjoying the GitHub package as well as the principled approach when considering new APIs and changes.  Users pop up from time to time wanting  to use another API and GitHub's insistence that many APIs remain beta for an extended period of time has been an hinderance - the machine-man-preview and shadowcat APIs for example.

Github-<api name> style packages can be made to support these APIs - it would be great to benefit from all the rich machinery developed here in the github package when doing so.  This PR has one small change that doesn't appear to impact the github package's major Haskell APIs, but helps tremendously with reusing github (package) on some preview github (web service) APIs.

Enough preamble!  This pull request relaxes PagedQuery from vector to any semigroup foldable.  That is:

```
PagedQuery   :: Paths -> QueryString -> FetchCount -> GenRequest mt rw (Vector a)
```

To:

```
PagedQuery   :: (a ~ t b, Foldable t, Semigroup a) => Paths -> QueryString -> FetchCount -> GenRequest mt rw a
```

The consumer of PagedQuery already was generalized to Semigroup but the predicate used vector length, so the consumer only needed to drop `V.` - using foldable length - and everything works as before.  That's all that is required for re-use of the pagination machinery for several not-yet-standard APIs.