### PR TITLE
Add endpoint to create gist

### DIFF
--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -62,7 +62,6 @@ module GitHub (
     -- Missing endpoints:
     --
     -- * Query a specific revision of a gist
-    -- * Create a gist
     -- * Edit a gist
     -- * List gist commits
     -- * Check if a gist is starred
@@ -70,6 +69,7 @@ module GitHub (
     -- * List gist forks
     gistsR,
     gistR,
+    createGistR,
     starGistR,
     unstarGistR,
     deleteGistR,

--- a/src/GitHub/Data/Gists.hs
+++ b/src/GitHub/Data/Gists.hs
@@ -100,14 +100,14 @@ instance NFData NewGist where rnf = genericRnf
 instance Binary NewGist
 
 instance ToJSON NewGist where
-    toJSON (NewGist { newGistDescription = description
-                    , newGistFiles       = files
-                    , newGistPublic      = public
-                    }) = object
-                    [ "description"      .= description
-                    , "files"            .= files
-                    , "public"           .= public
-                    ]
+    toJSON NewGist { newGistDescription = description
+                   , newGistFiles       = files
+                   , newGistPublic      = public
+                   } = object
+                   [ "description"      .= description
+                   , "files"            .= files
+                   , "public"           .= public
+                   ]
 
 data NewGistFile = NewGistFile
     { newGistFileContent :: !Text

--- a/src/GitHub/Data/Gists.hs
+++ b/src/GitHub/Data/Gists.hs
@@ -91,9 +91,9 @@ instance FromJSON GistComment where
         <*> o .: "id"
 
 data NewGist = NewGist
-    { newGistDescription :: !Text
+    { newGistDescription :: !(Maybe Text)
     , newGistFiles       :: !(HashMap Text NewGistFile)
-    , newGistPublic      :: !Bool
+    , newGistPublic      :: !(Maybe Bool)
     } deriving (Show, Data, Typeable, Eq, Generic)
 
 instance NFData NewGist where rnf = genericRnf
@@ -103,11 +103,14 @@ instance ToJSON NewGist where
     toJSON NewGist { newGistDescription = description
                    , newGistFiles       = files
                    , newGistPublic      = public
-                   } = object
+                   } = object $ filter notNull
                    [ "description"      .= description
                    , "files"            .= files
                    , "public"           .= public
                    ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _)    = True
 
 data NewGistFile = NewGistFile
     { newGistFileContent :: !Text

--- a/src/GitHub/Data/Gists.hs
+++ b/src/GitHub/Data/Gists.hs
@@ -89,3 +89,32 @@ instance FromJSON GistComment where
         <*> o .: "body"
         <*> o .: "updated_at"
         <*> o .: "id"
+
+data NewGist = NewGist
+    { newGistDescription :: !Text
+    , newGistFiles       :: !(HashMap Text NewGistFile)
+    , newGistPublic      :: !Bool
+    } deriving (Show, Data, Typeable, Eq, Generic)
+
+instance NFData NewGist where rnf = genericRnf
+instance Binary NewGist
+
+instance ToJSON NewGist where
+    toJSON (NewGist { newGistDescription = description
+                    , newGistFiles       = files
+                    , newGistPublic      = public
+                    }) = object
+                    [ "description"      .= description
+                    , "files"            .= files
+                    , "public"           .= public
+                    ]
+
+data NewGistFile = NewGistFile
+    { newGistFileContent :: !Text
+    } deriving (Show, Data, Typeable, Eq, Generic)
+
+instance NFData NewGistFile where rnf = genericRnf
+instance Binary NewGistFile
+
+instance ToJSON NewGistFile where
+    toJSON (NewGistFile c) = object ["content" .= c]

--- a/src/GitHub/Endpoints/Gists.hs
+++ b/src/GitHub/Endpoints/Gists.hs
@@ -7,6 +7,7 @@
 module GitHub.Endpoints.Gists (
     gistsR,
     gistR,
+    createGistR,
     starGistR,
     unstarGistR,
     deleteGistR,
@@ -27,6 +28,11 @@ gistsR user = pagedQuery ["users", toPathPart user, "gists"] []
 gistR :: Name Gist -> Request k Gist
 gistR gid =
     query ["gists", toPathPart gid] []
+
+-- | Create a new gist
+-- See <https://docs.github.com/rest/reference/gists#create-a-gist>
+createGistR :: NewGist -> Request 'RW Gist
+createGistR ngist = command Post ["gists"] (encode ngist)
 
 -- | Star a gist by the authenticated user.
 -- See <https://developer.github.com/v3/gists/#star-a-gist>


### PR DESCRIPTION
ref https://docs.github.com/rest/reference/gists#create-a-gist

```hs
ghci> github (OAuth "...") $ createGistR (NewGist "" (HashMap.fromList [("hoge.txt", NewGistFile "abc")]) False)
Right (Gist {...})
```

about `NewGist`'s fields: 

- `description` is optional param according to reference. But, when use `Maybe` type and `Nothing`, occur error `Invalid request.\\n\\nFor 'properties/description', nil is not a string.`. So, `description` param is `Text` type.
- `public` is optional param according to reference. But, when use `Maybe` type and `Nothing`,  occur error `Left (ParseError "Error in $.public: expected Bool, but encountered Null")`. So, `public` param is `Bool` type.